### PR TITLE
[WIP] Autoinitialize List Properties

### DIFF
--- a/Recurly/Client.cs
+++ b/Recurly/Client.cs
@@ -1356,30 +1356,32 @@ namespace Recurly
         /// Collect a pending or past due, automatic invoice <see href="https://developers.recurly.com/api/v2019-10-10#operation/collect_invoice">collect_invoice api documentation</see>
         /// </summary>
         /// <param name="invoiceId">Invoice ID or number (use prefix: `number-`, e.g. `number-1000`).</param>
+        /// <param name="body">The body of the request.</param>
         /// <returns>
         /// The updated invoice.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        public Invoice CollectInvoice(string invoiceId)
+        public Invoice CollectInvoice(string invoiceId, InvoiceCollect body)
         {
             var urlParams = new Dictionary<string, object> { { "invoice_id", invoiceId } };
             var url = this.InterpolatePath("/invoices/{invoice_id}/collect", urlParams);
-            return MakeRequest<Invoice>(Method.PUT, url, null, null);
+            return MakeRequest<Invoice>(Method.PUT, url, body, null);
         }
 
         /// <summary>
         /// Collect a pending or past due, automatic invoice <see href="https://developers.recurly.com/api/v2019-10-10#operation/collect_invoice">collect_invoice api documentation</see>
         /// </summary>
         /// <param name="invoiceId">Invoice ID or number (use prefix: `number-`, e.g. `number-1000`).</param>
+        /// <param name="body">The body of the request.</param>
         /// <returns>
         /// The updated invoice.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        public Task<Invoice> CollectInvoiceAsync(string invoiceId, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<Invoice> CollectInvoiceAsync(string invoiceId, InvoiceCollect body, CancellationToken cancellationToken = default(CancellationToken))
         {
             var urlParams = new Dictionary<string, object> { { "invoice_id", invoiceId } };
             var url = this.InterpolatePath("/invoices/{invoice_id}/collect", urlParams);
-            return MakeRequestAsync<Invoice>(Method.PUT, url, null, null, cancellationToken);
+            return MakeRequestAsync<Invoice>(Method.PUT, url, body, null, cancellationToken);
         }
 
         /// <summary>

--- a/Recurly/Resources/AccountCreate.cs
+++ b/Recurly/Resources/AccountCreate.cs
@@ -44,8 +44,14 @@ namespace Recurly.Resources
         public string Company { get; set; }
 
 
+        [JsonIgnore]
+        public List<CustomField> CustomFields
+        {
+            get { return _customFields ?? (_customFields = new List<CustomField>()); }
+            set { _customFields = value; }
+        }
         [JsonProperty("custom_fields")]
-        public List<CustomField> CustomFields { get; set; }
+        private List<CustomField> _customFields;
 
         /// <value>The email address used for communicating with this customer. The customer will also use this email address to log into your hosted account management pages. This value does not need to be unique.</value>
         [JsonProperty("email")]
@@ -76,12 +82,22 @@ namespace Recurly.Resources
         public string PreferredLocale { get; set; }
 
 
+        [JsonIgnore]
+        public List<ShippingAddressCreate> ShippingAddresses
+        {
+            get { return _shippingAddresses ?? (_shippingAddresses = new List<ShippingAddressCreate>()); }
+            set { _shippingAddresses = value; }
+        }
         [JsonProperty("shipping_addresses")]
-        public List<ShippingAddressCreate> ShippingAddresses { get; set; }
+        private List<ShippingAddressCreate> _shippingAddresses;
 
         /// <value>The tax status of the account. `true` exempts tax on the account, `false` applies tax on the account.</value>
         [JsonProperty("tax_exempt")]
         public bool? TaxExempt { get; set; }
+
+        /// <value>An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.</value>
+        [JsonProperty("transaction_type")]
+        public string TransactionType { get; set; }
 
         /// <value>A secondary value for the account.</value>
         [JsonProperty("username")]

--- a/Recurly/Resources/AccountPurchase.cs
+++ b/Recurly/Resources/AccountPurchase.cs
@@ -44,8 +44,14 @@ namespace Recurly.Resources
         public string Company { get; set; }
 
 
+        [JsonIgnore]
+        public List<CustomField> CustomFields
+        {
+            get { return _customFields ?? (_customFields = new List<CustomField>()); }
+            set { _customFields = value; }
+        }
         [JsonProperty("custom_fields")]
-        public List<CustomField> CustomFields { get; set; }
+        private List<CustomField> _customFields;
 
         /// <value>The email address used for communicating with this customer. The customer will also use this email address to log into your hosted account management pages. This value does not need to be unique.</value>
         [JsonProperty("email")]
@@ -82,6 +88,10 @@ namespace Recurly.Resources
         /// <value>The tax status of the account. `true` exempts tax on the account, `false` applies tax on the account.</value>
         [JsonProperty("tax_exempt")]
         public bool? TaxExempt { get; set; }
+
+        /// <value>An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.</value>
+        [JsonProperty("transaction_type")]
+        public string TransactionType { get; set; }
 
         /// <value>A secondary value for the account.</value>
         [JsonProperty("username")]

--- a/Recurly/Resources/AccountUpdate.cs
+++ b/Recurly/Resources/AccountUpdate.cs
@@ -36,8 +36,14 @@ namespace Recurly.Resources
         public string Company { get; set; }
 
 
+        [JsonIgnore]
+        public List<CustomField> CustomFields
+        {
+            get { return _customFields ?? (_customFields = new List<CustomField>()); }
+            set { _customFields = value; }
+        }
         [JsonProperty("custom_fields")]
-        public List<CustomField> CustomFields { get; set; }
+        private List<CustomField> _customFields;
 
         /// <value>The email address used for communicating with this customer. The customer will also use this email address to log into your hosted account management pages. This value does not need to be unique.</value>
         [JsonProperty("email")]
@@ -70,6 +76,10 @@ namespace Recurly.Resources
         /// <value>The tax status of the account. `true` exempts tax on the account, `false` applies tax on the account.</value>
         [JsonProperty("tax_exempt")]
         public bool? TaxExempt { get; set; }
+
+        /// <value>An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.</value>
+        [JsonProperty("transaction_type")]
+        public string TransactionType { get; set; }
 
         /// <value>A secondary value for the account.</value>
         [JsonProperty("username")]

--- a/Recurly/Resources/AddOnCreate.cs
+++ b/Recurly/Resources/AddOnCreate.cs
@@ -24,8 +24,14 @@ namespace Recurly.Resources
         public string Code { get; set; }
 
         /// <value>Add-on pricing</value>
+        [JsonIgnore]
+        public List<AddOnPricing> Currencies
+        {
+            get { return _currencies ?? (_currencies = new List<AddOnPricing>()); }
+            set { _currencies = value; }
+        }
         [JsonProperty("currencies")]
-        public List<AddOnPricing> Currencies { get; set; }
+        private List<AddOnPricing> _currencies;
 
         /// <value>Default quantity for the hosted pages.</value>
         [JsonProperty("default_quantity")]

--- a/Recurly/Resources/AddOnUpdate.cs
+++ b/Recurly/Resources/AddOnUpdate.cs
@@ -24,8 +24,14 @@ namespace Recurly.Resources
         public string Code { get; set; }
 
         /// <value>Add-on pricing</value>
+        [JsonIgnore]
+        public List<AddOnPricing> Currencies
+        {
+            get { return _currencies ?? (_currencies = new List<AddOnPricing>()); }
+            set { _currencies = value; }
+        }
         [JsonProperty("currencies")]
-        public List<AddOnPricing> Currencies { get; set; }
+        private List<AddOnPricing> _currencies;
 
         /// <value>Default quantity for the hosted pages.</value>
         [JsonProperty("default_quantity")]

--- a/Recurly/Resources/BillingInfoCreate.cs
+++ b/Recurly/Resources/BillingInfoCreate.cs
@@ -63,6 +63,10 @@ namespace Recurly.Resources
         [JsonProperty("token_id")]
         public string TokenId { get; set; }
 
+        /// <value>An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.</value>
+        [JsonProperty("transaction_type")]
+        public string TransactionType { get; set; }
+
         /// <value>VAT number</value>
         [JsonProperty("vat_number")]
         public string VatNumber { get; set; }

--- a/Recurly/Resources/CouponCreate.cs
+++ b/Recurly/Resources/CouponCreate.cs
@@ -32,8 +32,14 @@ namespace Recurly.Resources
         public string CouponType { get; set; }
 
         /// <value>Fixed discount currencies by currency. Required if the coupon type is `fixed`. This parameter should contain the coupon discount values</value>
+        [JsonIgnore]
+        public List<CouponPricing> Currencies
+        {
+            get { return _currencies ?? (_currencies = new List<CouponPricing>()); }
+            set { _currencies = value; }
+        }
         [JsonProperty("currencies")]
-        public List<CouponPricing> Currencies { get; set; }
+        private List<CouponPricing> _currencies;
 
         /// <value>The percent of the price discounted by the coupon.  Required if `discount_type` is `percent`.</value>
         [JsonProperty("discount_percent")]
@@ -81,8 +87,14 @@ namespace Recurly.Resources
         public string Name { get; set; }
 
         /// <value>List of plan codes to which this coupon applies. See `applies_to_all_plans`</value>
+        [JsonIgnore]
+        public List<string> PlanCodes
+        {
+            get { return _planCodes ?? (_planCodes = new List<string>()); }
+            set { _planCodes = value; }
+        }
         [JsonProperty("plan_codes")]
-        public List<string> PlanCodes { get; set; }
+        private List<string> _planCodes;
 
         /// <value>The date and time the coupon will expire and can no longer be redeemed. Time is always 11:59:59, the end-of-day Pacific time.</value>
         [JsonProperty("redeem_by_date")]

--- a/Recurly/Resources/InvoiceCollect.cs
+++ b/Recurly/Resources/InvoiceCollect.cs
@@ -1,0 +1,23 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+    [ExcludeFromCodeCoverage]
+    public class InvoiceCollect : Request
+    {
+
+        /// <value>An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.</value>
+        [JsonProperty("transaction_type")]
+        public string TransactionType { get; set; }
+
+    }
+}

--- a/Recurly/Resources/InvoiceRefund.cs
+++ b/Recurly/Resources/InvoiceRefund.cs
@@ -44,8 +44,14 @@ namespace Recurly.Resources
         public ExternalRefund ExternalRefund { get; set; }
 
         /// <value>The line items to be refunded. This is required when `type=line_items`.</value>
+        [JsonIgnore]
+        public List<LineItemRefund> LineItems
+        {
+            get { return _lineItems ?? (_lineItems = new List<LineItemRefund>()); }
+            set { _lineItems = value; }
+        }
         [JsonProperty("line_items")]
-        public List<LineItemRefund> LineItems { get; set; }
+        private List<LineItemRefund> _lineItems;
 
         /// <value>
         /// Indicates how the invoice should be refunded when both a credit and transaction are present on the invoice:

--- a/Recurly/Resources/PlanCreate.cs
+++ b/Recurly/Resources/PlanCreate.cs
@@ -20,8 +20,14 @@ namespace Recurly.Resources
         public string AccountingCode { get; set; }
 
         /// <value>Add Ons</value>
+        [JsonIgnore]
+        public List<AddOnCreate> AddOns
+        {
+            get { return _addOns ?? (_addOns = new List<AddOnCreate>()); }
+            set { _addOns = value; }
+        }
         [JsonProperty("add_ons")]
-        public List<AddOnCreate> AddOns { get; set; }
+        private List<AddOnCreate> _addOns;
 
         /// <value>Subscriptions will automatically inherit this value once they are active. If `auto_renew` is `true`, then a subscription will automatically renew its term at renewal. If `auto_renew` is `false`, then a subscription will expire at the end of its term. `auto_renew` can be overridden on the subscription record itself.</value>
         [JsonProperty("auto_renew")]
@@ -32,8 +38,14 @@ namespace Recurly.Resources
         public string Code { get; set; }
 
         /// <value>Pricing</value>
+        [JsonIgnore]
+        public List<PlanPricing> Currencies
+        {
+            get { return _currencies ?? (_currencies = new List<PlanPricing>()); }
+            set { _currencies = value; }
+        }
         [JsonProperty("currencies")]
-        public List<PlanPricing> Currencies { get; set; }
+        private List<PlanPricing> _currencies;
 
         /// <value>Optional description, not displayed.</value>
         [JsonProperty("description")]

--- a/Recurly/Resources/PlanUpdate.cs
+++ b/Recurly/Resources/PlanUpdate.cs
@@ -20,8 +20,14 @@ namespace Recurly.Resources
         public string AccountingCode { get; set; }
 
         /// <value>Add Ons</value>
+        [JsonIgnore]
+        public List<AddOnCreate> AddOns
+        {
+            get { return _addOns ?? (_addOns = new List<AddOnCreate>()); }
+            set { _addOns = value; }
+        }
         [JsonProperty("add_ons")]
-        public List<AddOnCreate> AddOns { get; set; }
+        private List<AddOnCreate> _addOns;
 
         /// <value>Subscriptions will automatically inherit this value once they are active. If `auto_renew` is `true`, then a subscription will automatically renew its term at renewal. If `auto_renew` is `false`, then a subscription will expire at the end of its term. `auto_renew` can be overridden on the subscription record itself.</value>
         [JsonProperty("auto_renew")]
@@ -32,8 +38,14 @@ namespace Recurly.Resources
         public string Code { get; set; }
 
         /// <value>Pricing</value>
+        [JsonIgnore]
+        public List<PlanPricing> Currencies
+        {
+            get { return _currencies ?? (_currencies = new List<PlanPricing>()); }
+            set { _currencies = value; }
+        }
         [JsonProperty("currencies")]
-        public List<PlanPricing> Currencies { get; set; }
+        private List<PlanPricing> _currencies;
 
         /// <value>Optional description, not displayed.</value>
         [JsonProperty("description")]

--- a/Recurly/Resources/PurchaseCreate.cs
+++ b/Recurly/Resources/PurchaseCreate.cs
@@ -24,8 +24,14 @@ namespace Recurly.Resources
         public string CollectionMethod { get; set; }
 
         /// <value>A list of coupon_codes to be redeemed on the subscription or account during the purchase.</value>
+        [JsonIgnore]
+        public List<string> CouponCodes
+        {
+            get { return _couponCodes ?? (_couponCodes = new List<string>()); }
+            set { _couponCodes = value; }
+        }
         [JsonProperty("coupon_codes")]
-        public List<string> CouponCodes { get; set; }
+        private List<string> _couponCodes;
 
         /// <value>Notes to be put on the credit invoice resulting from credits in the purchase, if any.</value>
         [JsonProperty("credit_customer_notes")]
@@ -48,8 +54,14 @@ namespace Recurly.Resources
         public string GiftCardRedemptionCode { get; set; }
 
         /// <value>A list of one time charges or credits to be created with the purchase.</value>
+        [JsonIgnore]
+        public List<LineItemCreate> LineItems
+        {
+            get { return _lineItems ?? (_lineItems = new List<LineItemCreate>()); }
+            set { _lineItems = value; }
+        }
         [JsonProperty("line_items")]
-        public List<LineItemCreate> LineItems { get; set; }
+        private List<LineItemCreate> _lineItems;
 
         /// <value>Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.</value>
         [JsonProperty("net_terms")]
@@ -64,12 +76,22 @@ namespace Recurly.Resources
         public ShippingPurchase Shipping { get; set; }
 
         /// <value>A list of subscriptions to be created with the purchase.</value>
+        [JsonIgnore]
+        public List<SubscriptionPurchase> Subscriptions
+        {
+            get { return _subscriptions ?? (_subscriptions = new List<SubscriptionPurchase>()); }
+            set { _subscriptions = value; }
+        }
         [JsonProperty("subscriptions")]
-        public List<SubscriptionPurchase> Subscriptions { get; set; }
+        private List<SubscriptionPurchase> _subscriptions;
 
         /// <value>Terms and conditions to be put on the purchase invoice.</value>
         [JsonProperty("terms_and_conditions")]
         public string TermsAndConditions { get; set; }
+
+        /// <value>An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.</value>
+        [JsonProperty("transaction_type")]
+        public string TransactionType { get; set; }
 
         /// <value>VAT reverse charge notes for cross border European tax settlement.</value>
         [JsonProperty("vat_reverse_charge_notes")]

--- a/Recurly/Resources/ShippingPurchase.cs
+++ b/Recurly/Resources/ShippingPurchase.cs
@@ -24,8 +24,14 @@ namespace Recurly.Resources
         public string AddressId { get; set; }
 
         /// <value>A list of shipping fees to be created as charges with the purchase.</value>
+        [JsonIgnore]
+        public List<ShippingFeeCreate> Fees
+        {
+            get { return _fees ?? (_fees = new List<ShippingFeeCreate>()); }
+            set { _fees = value; }
+        }
         [JsonProperty("fees")]
-        public List<ShippingFeeCreate> Fees { get; set; }
+        private List<ShippingFeeCreate> _fees;
 
     }
 }

--- a/Recurly/Resources/SubscriptionChangeCreate.cs
+++ b/Recurly/Resources/SubscriptionChangeCreate.cs
@@ -16,16 +16,28 @@ namespace Recurly.Resources
     {
 
         /// <value>If you provide a value for this field it will replace any existing add-ons. So, when adding or modifying an add-on, you need to include the existing subscription add-ons. Unchanged add-ons can be included just using the subscription add-on's ID: `{"id": "abc123"}`.</value>
+        [JsonIgnore]
+        public List<SubscriptionAddOnUpdate> AddOns
+        {
+            get { return _addOns ?? (_addOns = new List<SubscriptionAddOnUpdate>()); }
+            set { _addOns = value; }
+        }
         [JsonProperty("add_ons")]
-        public List<SubscriptionAddOnUpdate> AddOns { get; set; }
+        private List<SubscriptionAddOnUpdate> _addOns;
 
         /// <value>Collection method</value>
         [JsonProperty("collection_method")]
         public string CollectionMethod { get; set; }
 
         /// <value>A list of coupon_codes to be redeemed on the subscription during the change. Only allowed if timeframe is now and you change something about the subscription that creates an invoice.</value>
+        [JsonIgnore]
+        public List<string> CouponCodes
+        {
+            get { return _couponCodes ?? (_couponCodes = new List<string>()); }
+            set { _couponCodes = value; }
+        }
         [JsonProperty("coupon_codes")]
-        public List<string> CouponCodes { get; set; }
+        private List<string> _couponCodes;
 
         /// <value>Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.</value>
         [JsonProperty("net_terms")]
@@ -54,6 +66,10 @@ namespace Recurly.Resources
         /// <value>The timeframe parameter controls when the upgrade or downgrade takes place. The subscription change can occur now, when the subscription is next billed, or when the subscription renews. Generally, if you're performing an upgrade, you will want the change to occur immediately (now). If you're performing a downgrade, you should set the timeframe to "renewal" so the change takes affect at the end of the current subscription term.</value>
         [JsonProperty("timeframe")]
         public string Timeframe { get; set; }
+
+        /// <value>An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.</value>
+        [JsonProperty("transaction_type")]
+        public string TransactionType { get; set; }
 
         /// <value>Optionally, sets custom pricing for the subscription, overriding the plan's default unit amount. The subscription's current currency will be used.</value>
         [JsonProperty("unit_amount")]

--- a/Recurly/Resources/SubscriptionCreate.cs
+++ b/Recurly/Resources/SubscriptionCreate.cs
@@ -20,8 +20,14 @@ namespace Recurly.Resources
         public AccountCreate Account { get; set; }
 
         /// <value>Add-ons</value>
+        [JsonIgnore]
+        public List<SubscriptionAddOnCreate> AddOns
+        {
+            get { return _addOns ?? (_addOns = new List<SubscriptionAddOnCreate>()); }
+            set { _addOns = value; }
+        }
         [JsonProperty("add_ons")]
-        public List<SubscriptionAddOnCreate> AddOns { get; set; }
+        private List<SubscriptionAddOnCreate> _addOns;
 
         /// <value>Whether the subscription renews at the end of its term.</value>
         [JsonProperty("auto_renew")]
@@ -44,8 +50,14 @@ namespace Recurly.Resources
         public string Currency { get; set; }
 
 
+        [JsonIgnore]
+        public List<CustomField> CustomFields
+        {
+            get { return _customFields ?? (_customFields = new List<CustomField>()); }
+            set { _customFields = value; }
+        }
         [JsonProperty("custom_fields")]
-        public List<CustomField> CustomFields { get; set; }
+        private List<CustomField> _customFields;
 
         /// <value>This will default to the Customer Notes text specified on the Invoice Settings. Specify custom notes to add or override Customer Notes. Custom notes will stay with a subscription on all renewals.</value>
         [JsonProperty("customer_notes")]
@@ -94,6 +106,10 @@ namespace Recurly.Resources
         /// <value>The number of cycles/billing periods in a term. When `remaining_billing_cycles=0`, if `auto_renew=true` the subscription will renew and a new term will begin, otherwise the subscription will expire.</value>
         [JsonProperty("total_billing_cycles")]
         public int? TotalBillingCycles { get; set; }
+
+        /// <value>An optional type designation for the payment gateway transaction created by this request. Supports 'moto' value, which is the acronym for mail order and telephone transactions.</value>
+        [JsonProperty("transaction_type")]
+        public string TransactionType { get; set; }
 
         /// <value>If set, overrides the default trial behavior for the subscription. The date must be in the future.</value>
         [JsonProperty("trial_ends_at")]

--- a/Recurly/Resources/SubscriptionPurchase.cs
+++ b/Recurly/Resources/SubscriptionPurchase.cs
@@ -16,16 +16,28 @@ namespace Recurly.Resources
     {
 
         /// <value>Add-ons</value>
+        [JsonIgnore]
+        public List<SubscriptionAddOnCreate> AddOns
+        {
+            get { return _addOns ?? (_addOns = new List<SubscriptionAddOnCreate>()); }
+            set { _addOns = value; }
+        }
         [JsonProperty("add_ons")]
-        public List<SubscriptionAddOnCreate> AddOns { get; set; }
+        private List<SubscriptionAddOnCreate> _addOns;
 
         /// <value>Whether the subscription renews at the end of its term.</value>
         [JsonProperty("auto_renew")]
         public bool? AutoRenew { get; set; }
 
 
+        [JsonIgnore]
+        public List<CustomField> CustomFields
+        {
+            get { return _customFields ?? (_customFields = new List<CustomField>()); }
+            set { _customFields = value; }
+        }
         [JsonProperty("custom_fields")]
-        public List<CustomField> CustomFields { get; set; }
+        private List<CustomField> _customFields;
 
         /// <value>If present, this sets the date the subscription's next billing period will start (`current_period_ends_at`). This can be used to align the subscription’s billing to a specific day of the month. The initial invoice will be prorated for the period between the subscription's activation date and the billing period end date. Subsequent periods will be based off the plan interval. For a subscription with a trial period, this will change when the trial expires.</value>
         [JsonProperty("next_bill_date")]

--- a/Recurly/Resources/SubscriptionUpdate.cs
+++ b/Recurly/Resources/SubscriptionUpdate.cs
@@ -24,8 +24,14 @@ namespace Recurly.Resources
         public string CollectionMethod { get; set; }
 
 
+        [JsonIgnore]
+        public List<CustomField> CustomFields
+        {
+            get { return _customFields ?? (_customFields = new List<CustomField>()); }
+            set { _customFields = value; }
+        }
         [JsonProperty("custom_fields")]
-        public List<CustomField> CustomFields { get; set; }
+        private List<CustomField> _customFields;
 
         /// <value>Specify custom notes to add or override Customer Notes. Custom notes will stay with a subscription on all renewals.</value>
         [JsonProperty("customer_notes")]


### PR DESCRIPTION
Resolves #455 

This allows you to `Add` to List properties in Request objects without initializing them, reducing chance of NPEs. I'm still looking at how this affects serialzation / deserialization. We might want to avoid this if it affects that behavior. Example:

```csharp
var accountReq = new AccountCreate()
{
    Code = accountCode,
};
accountReq.ShippingAddresses.Add(new ShippingAddressCreate() {
    FirstName = "Benjamin",
    LastName = "Du Monde",
    Street1 = "123 Tchoupitoulas St",
    City = "New Orleans",
    Region = "LA",
    PostalCode = "70130",
    Country = "US"
});
Account account = client.CreateAccount(accountReq);
```