### PR TITLE
Convert Floats to Decimals with Monetary Amounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ msbuild.wrn
 
 coverage.*
 coverage_report/
+
+packages/
+.idea/

--- a/Recurly.Tests/Fixtures.cs
+++ b/Recurly.Tests/Fixtures.cs
@@ -10,8 +10,8 @@ namespace Recurly.Tests
         [JsonProperty("my_string")]
         public string MyString { get; set; }
 
-        [JsonProperty("my_float")]
-        public float? MyFloat { get; set; }
+        [JsonProperty("my_decimal")]
+        public decimal? MyDecimal { get; set; }
 
         [JsonProperty("my_int")]
         public int? MyInt { get; set; }

--- a/Recurly.Tests/JsonSerializerTest.cs
+++ b/Recurly.Tests/JsonSerializerTest.cs
@@ -26,10 +26,10 @@ namespace Recurly.Tests
         public void Deserialize()
         {
             // make sure it can deserialize all primitive types and convert b/w snake and camel case
-            var json = "{\"my_string\":\"benjamin\",\"my_float\":3.14,\"my_int\": 3}";
+            var json = "{\"my_string\":\"benjamin\",\"my_decimal\":3.14,\"my_int\": 3}";
             var resource = _jsonSerializer.Deserialize<MyResource>(MockResourceResponse(json));
             Assert.Equal("benjamin", resource.MyString);
-            Assert.Equal(3.14f, resource.MyFloat);
+            Assert.Equal(3.14m, resource.MyDecimal);
             Assert.Equal(3, resource.MyInt);
         }
 
@@ -83,7 +83,7 @@ namespace Recurly.Tests
             var resource = new MyResource()
             {
                 MyString = "benjamin",
-                MyFloat = 3.14f,
+                MyDecimal = 3.14m,
                 MyInt = 3,
                 MySubResource = new MySubResource() { MyString = "subresource" },
                 MyArrayString = new List<string>() { "a", "b" },
@@ -94,7 +94,7 @@ namespace Recurly.Tests
                 }
             };
             var jsonStr = _jsonSerializer.Serialize(resource);
-            var json = "{\"my_string\":\"benjamin\",\"my_float\":3.14,\"my_int\":3,\"my_sub_resource\":{\"my_string\":\"subresource\"},\"my_array_string\":[\"a\",\"b\"],\"my_array_sub_resource\":[{\"my_string\":\"subresource1\"},{\"my_string\":\"subresource2\"}]}";
+            var json = "{\"my_string\":\"benjamin\",\"my_decimal\":3.14,\"my_int\":3,\"my_sub_resource\":{\"my_string\":\"subresource\"},\"my_array_string\":[\"a\",\"b\"],\"my_array_sub_resource\":[{\"my_string\":\"subresource1\"},{\"my_string\":\"subresource2\"}]}";
             Assert.Equal(jsonStr, json);
         }
         private RestSharp.IRestResponse MockResourceResponse(string json)

--- a/Recurly.Tests/UtilsTest.cs
+++ b/Recurly.Tests/UtilsTest.cs
@@ -26,10 +26,10 @@ namespace Recurly.Tests
             d.Add("trueBool", true);
             d.Add("falseBool", false);
             d.Add("int", 123);
-            d.Add("float", 123.456);
-            d.Add("date", new DateTime(2020, 1, 1));
+            d.Add("decimal", 123.456m);
+            d.Add("date", new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc));
             var result = Utils.QueryString(d);
-            Assert.Equal("?trueBool=true&falseBool=false&int=123&float=123.456&date=2020-01-01T00:00:00.000Z", result);
+            Assert.Equal("?trueBool=true&falseBool=false&int=123&decimal=123.456&date=2020-01-01T00:00:00.000Z", result);
         }
     }
 }

--- a/Recurly/Resources/AccountAcquisitionCost.cs
+++ b/Recurly/Resources/AccountAcquisitionCost.cs
@@ -17,7 +17,7 @@ namespace Recurly.Resources
 
         /// <value>The amount of the corresponding currency used to acquire the account.</value>
         [JsonProperty("amount")]
-        public float? Amount { get; set; }
+        public decimal? Amount { get; set; }
 
         /// <value>3-letter ISO 4217 currency code.</value>
         [JsonProperty("currency")]

--- a/Recurly/Resources/AccountBalanceAmount.cs
+++ b/Recurly/Resources/AccountBalanceAmount.cs
@@ -17,7 +17,7 @@ namespace Recurly.Resources
 
         /// <value>Total amount the account is past due.</value>
         [JsonProperty("amount")]
-        public float? Amount { get; set; }
+        public decimal? Amount { get; set; }
 
         /// <value>3-letter ISO 4217 currency code.</value>
         [JsonProperty("currency")]

--- a/Recurly/Resources/AddOnPricing.cs
+++ b/Recurly/Resources/AddOnPricing.cs
@@ -21,7 +21,7 @@ namespace Recurly.Resources
 
         /// <value>Unit price</value>
         [JsonProperty("unit_amount")]
-        public float? UnitAmount { get; set; }
+        public decimal? UnitAmount { get; set; }
 
     }
 }

--- a/Recurly/Resources/CouponDiscountPricing.cs
+++ b/Recurly/Resources/CouponDiscountPricing.cs
@@ -17,7 +17,7 @@ namespace Recurly.Resources
 
         /// <value>Value of the fixed discount that this coupon applies.</value>
         [JsonProperty("amount")]
-        public float? Amount { get; set; }
+        public decimal? Amount { get; set; }
 
         /// <value>3-letter ISO 4217 currency code.</value>
         [JsonProperty("currency")]

--- a/Recurly/Resources/CouponPricing.cs
+++ b/Recurly/Resources/CouponPricing.cs
@@ -21,7 +21,7 @@ namespace Recurly.Resources
 
         /// <value>The fixed discount (in dollars) for the corresponding currency.</value>
         [JsonProperty("discount")]
-        public float? Discount { get; set; }
+        public decimal? Discount { get; set; }
 
     }
 }

--- a/Recurly/Resources/CouponRedemption.cs
+++ b/Recurly/Resources/CouponRedemption.cs
@@ -33,7 +33,7 @@ namespace Recurly.Resources
 
         /// <value>The amount that was discounted upon the application of the coupon, formatted with the currency.</value>
         [JsonProperty("discounted")]
-        public float? Discounted { get; set; }
+        public decimal? Discounted { get; set; }
 
         /// <value>Coupon Redemption ID</value>
         [JsonProperty("id")]

--- a/Recurly/Resources/CouponRedemptionMini.cs
+++ b/Recurly/Resources/CouponRedemptionMini.cs
@@ -25,7 +25,7 @@ namespace Recurly.Resources
 
         /// <value>The amount that was discounted upon the application of the coupon, formatted with the currency.</value>
         [JsonProperty("discounted")]
-        public float? Discounted { get; set; }
+        public decimal? Discounted { get; set; }
 
         /// <value>Coupon Redemption ID</value>
         [JsonProperty("id")]

--- a/Recurly/Resources/CreditPayment.cs
+++ b/Recurly/Resources/CreditPayment.cs
@@ -25,7 +25,7 @@ namespace Recurly.Resources
 
         /// <value>Total credit payment amount applied to the charge invoice.</value>
         [JsonProperty("amount")]
-        public float? Amount { get; set; }
+        public decimal? Amount { get; set; }
 
         /// <value>Invoice mini details</value>
         [JsonProperty("applied_to_invoice")]

--- a/Recurly/Resources/Invoice.cs
+++ b/Recurly/Resources/Invoice.cs
@@ -25,7 +25,7 @@ namespace Recurly.Resources
 
         /// <value>The outstanding balance remaining on this invoice.</value>
         [JsonProperty("balance")]
-        public float? Balance { get; set; }
+        public decimal? Balance { get; set; }
 
         /// <value>Date invoice was marked paid or failed.</value>
         [JsonProperty("closed_at")]
@@ -53,7 +53,7 @@ namespace Recurly.Resources
 
         /// <value>Total discounts applied to this invoice.</value>
         [JsonProperty("discount")]
-        public float? Discount { get; set; }
+        public decimal? Discount { get; set; }
 
         /// <value>Date invoice is due. This is the date the net terms are reached.</value>
         [JsonProperty("due_at")]
@@ -85,7 +85,7 @@ namespace Recurly.Resources
 
         /// <value>The total amount of successful payments transaction on this invoice.</value>
         [JsonProperty("paid")]
-        public float? Paid { get; set; }
+        public decimal? Paid { get; set; }
 
         /// <value>For manual invoicing, this identifies the PO number associated with the subscription.</value>
         [JsonProperty("po_number")]
@@ -97,7 +97,7 @@ namespace Recurly.Resources
 
         /// <value>The refundable amount on a charge invoice. It will be null for all other invoices.</value>
         [JsonProperty("refundable_amount")]
-        public float? RefundableAmount { get; set; }
+        public decimal? RefundableAmount { get; set; }
 
 
         [JsonProperty("shipping_address")]
@@ -113,11 +113,11 @@ namespace Recurly.Resources
 
         /// <value>The summation of charges, discounts, and credits, before tax.</value>
         [JsonProperty("subtotal")]
-        public float? Subtotal { get; set; }
+        public decimal? Subtotal { get; set; }
 
         /// <value>The total tax on this invoice.</value>
         [JsonProperty("tax")]
-        public float? Tax { get; set; }
+        public decimal? Tax { get; set; }
 
         /// <value>Tax info</value>
         [JsonProperty("tax_info")]
@@ -129,7 +129,7 @@ namespace Recurly.Resources
 
         /// <value>The final total on this invoice. The summation of invoice charges, discounts, credits, and tax.</value>
         [JsonProperty("total")]
-        public float? Total { get; set; }
+        public decimal? Total { get; set; }
 
         /// <value>Transactions</value>
         [JsonProperty("transactions")]

--- a/Recurly/Resources/LineItem.cs
+++ b/Recurly/Resources/LineItem.cs
@@ -33,7 +33,7 @@ namespace Recurly.Resources
 
         /// <value>`(quantity * unit_amount) - (discount + tax)`</value>
         [JsonProperty("amount")]
-        public float? Amount { get; set; }
+        public decimal? Amount { get; set; }
 
         /// <value>When the line item was created.</value>
         [JsonProperty("created_at")]
@@ -41,7 +41,7 @@ namespace Recurly.Resources
 
         /// <value>The amount of credit from this line item that was applied to the invoice.</value>
         [JsonProperty("credit_applied")]
-        public float? CreditApplied { get; set; }
+        public decimal? CreditApplied { get; set; }
 
         /// <value>The reason the credit was given when line item is `type=credit`.</value>
         [JsonProperty("credit_reason_code")]
@@ -57,7 +57,7 @@ namespace Recurly.Resources
 
         /// <value>The discount applied to the line item.</value>
         [JsonProperty("discount")]
-        public float? Discount { get; set; }
+        public decimal? Discount { get; set; }
 
         /// <value>If this date is provided, it indicates the end of a time range.</value>
         [JsonProperty("end_date")]
@@ -127,7 +127,7 @@ namespace Recurly.Resources
 
         /// <value>When a line item has been prorated, this is the rate of the proration. Proration rates were made available for line items created after March 30, 2017. For line items created prior to that date, the proration rate will be `null`, even if the line item was prorated.</value>
         [JsonProperty("proration_rate")]
-        public float? ProrationRate { get; set; }
+        public decimal? ProrationRate { get; set; }
 
         /// <value>This number will be multiplied by the unit amount to compute the subtotal before any discounts or taxes.</value>
         [JsonProperty("quantity")]
@@ -163,11 +163,11 @@ namespace Recurly.Resources
 
         /// <value>`quantity * unit_amount`</value>
         [JsonProperty("subtotal")]
-        public float? Subtotal { get; set; }
+        public decimal? Subtotal { get; set; }
 
         /// <value>The tax amount for the line item.</value>
         [JsonProperty("tax")]
-        public float? Tax { get; set; }
+        public decimal? Tax { get; set; }
 
         /// <value>Used by Avalara, Vertex, and Recurly’s EU VAT tax feature. The tax code values are specific to each tax system. If you are using Recurly’s EU VAT feature you can use `unknown`, `physical`, or `digital`.</value>
         [JsonProperty("tax_code")]
@@ -191,7 +191,7 @@ namespace Recurly.Resources
 
         /// <value>Positive amount for a charge, negative amount for a credit.</value>
         [JsonProperty("unit_amount")]
-        public float? UnitAmount { get; set; }
+        public decimal? UnitAmount { get; set; }
 
         /// <value>When the line item was last changed.</value>
         [JsonProperty("updated_at")]

--- a/Recurly/Resources/LineItemCreate.cs
+++ b/Recurly/Resources/LineItemCreate.cs
@@ -81,7 +81,7 @@ namespace Recurly.Resources
         /// If `item_code`/`item_id` is present, `unit_amount` can be passed in, to override the `Item`'s `unit_amount`. If `item_code`/`item_id` is not present then `unit_amount` is required.
         /// </value>
         [JsonProperty("unit_amount")]
-        public float? UnitAmount { get; set; }
+        public decimal? UnitAmount { get; set; }
 
     }
 }

--- a/Recurly/Resources/PlanPricing.cs
+++ b/Recurly/Resources/PlanPricing.cs
@@ -21,11 +21,11 @@ namespace Recurly.Resources
 
         /// <value>Amount of one-time setup fee automatically charged at the beginning of a subscription billing cycle. For subscription plans with a trial, the setup fee will be charged at the time of signup. Setup fees do not increase with the quantity of a subscription plan.</value>
         [JsonProperty("setup_fee")]
-        public float? SetupFee { get; set; }
+        public decimal? SetupFee { get; set; }
 
         /// <value>Unit price</value>
         [JsonProperty("unit_amount")]
-        public float? UnitAmount { get; set; }
+        public decimal? UnitAmount { get; set; }
 
     }
 }

--- a/Recurly/Resources/Pricing.cs
+++ b/Recurly/Resources/Pricing.cs
@@ -21,7 +21,7 @@ namespace Recurly.Resources
 
         /// <value>Unit price</value>
         [JsonProperty("unit_amount")]
-        public float? UnitAmount { get; set; }
+        public decimal? UnitAmount { get; set; }
 
     }
 }

--- a/Recurly/Resources/ShippingFeeCreate.cs
+++ b/Recurly/Resources/ShippingFeeCreate.cs
@@ -17,7 +17,7 @@ namespace Recurly.Resources
 
         /// <value>This is priced in the purchase's currency.</value>
         [JsonProperty("amount")]
-        public float? Amount { get; set; }
+        public decimal? Amount { get; set; }
 
         /// <value>The code of the shipping method used to deliver the purchase. If `method_id` and `method_code` are both present, `method_id` will be used.</value>
         [JsonProperty("method_code")]

--- a/Recurly/Resources/Subscription.cs
+++ b/Recurly/Resources/Subscription.cs
@@ -29,7 +29,7 @@ namespace Recurly.Resources
 
         /// <value>Total price of add-ons</value>
         [JsonProperty("add_ons_total")]
-        public float? AddOnsTotal { get; set; }
+        public decimal? AddOnsTotal { get; set; }
 
         /// <value>Whether the subscription renews at the end of its term.</value>
         [JsonProperty("auto_renew")]
@@ -145,7 +145,7 @@ namespace Recurly.Resources
 
         /// <value>Estimated total, before tax.</value>
         [JsonProperty("subtotal")]
-        public float? Subtotal { get; set; }
+        public decimal? Subtotal { get; set; }
 
         /// <value>Terms and conditions</value>
         [JsonProperty("terms_and_conditions")]
@@ -165,7 +165,7 @@ namespace Recurly.Resources
 
         /// <value>Subscription unit price</value>
         [JsonProperty("unit_amount")]
-        public float? UnitAmount { get; set; }
+        public decimal? UnitAmount { get; set; }
 
         /// <value>Last updated at</value>
         [JsonProperty("updated_at")]

--- a/Recurly/Resources/SubscriptionAddOn.cs
+++ b/Recurly/Resources/SubscriptionAddOn.cs
@@ -45,7 +45,7 @@ namespace Recurly.Resources
 
         /// <value>This is priced in the subscription's currency.</value>
         [JsonProperty("unit_amount")]
-        public float? UnitAmount { get; set; }
+        public decimal? UnitAmount { get; set; }
 
         /// <value>Updated at</value>
         [JsonProperty("updated_at")]

--- a/Recurly/Resources/SubscriptionAddOnCreate.cs
+++ b/Recurly/Resources/SubscriptionAddOnCreate.cs
@@ -25,7 +25,7 @@ namespace Recurly.Resources
 
         /// <value>Optionally, override the add-on's default unit amount.</value>
         [JsonProperty("unit_amount")]
-        public float? UnitAmount { get; set; }
+        public decimal? UnitAmount { get; set; }
 
     }
 }

--- a/Recurly/Resources/SubscriptionAddOnUpdate.cs
+++ b/Recurly/Resources/SubscriptionAddOnUpdate.cs
@@ -29,7 +29,7 @@ namespace Recurly.Resources
 
         /// <value>Optionally, override the add-on's default unit amount.</value>
         [JsonProperty("unit_amount")]
-        public float? UnitAmount { get; set; }
+        public decimal? UnitAmount { get; set; }
 
     }
 }

--- a/Recurly/Resources/SubscriptionChange.cs
+++ b/Recurly/Resources/SubscriptionChange.cs
@@ -61,7 +61,7 @@ namespace Recurly.Resources
 
         /// <value>Unit amount</value>
         [JsonProperty("unit_amount")]
-        public float? UnitAmount { get; set; }
+        public decimal? UnitAmount { get; set; }
 
         /// <value>Updated at</value>
         [JsonProperty("updated_at")]

--- a/Recurly/Resources/SubscriptionChangeCreate.cs
+++ b/Recurly/Resources/SubscriptionChangeCreate.cs
@@ -61,7 +61,7 @@ namespace Recurly.Resources
 
         /// <value>Optionally, sets custom pricing for the subscription, overriding the plan's default unit amount. The subscription's current currency will be used.</value>
         [JsonProperty("unit_amount")]
-        public float? UnitAmount { get; set; }
+        public decimal? UnitAmount { get; set; }
 
     }
 }

--- a/Recurly/Resources/SubscriptionChangeShippingCreate.cs
+++ b/Recurly/Resources/SubscriptionChangeShippingCreate.cs
@@ -17,7 +17,7 @@ namespace Recurly.Resources
 
         /// <value>Assigns the subscription's shipping cost. If this is greater than zero then a `method_id` or `method_code` is required.</value>
         [JsonProperty("amount")]
-        public float? Amount { get; set; }
+        public decimal? Amount { get; set; }
 
         /// <value>The code of the shipping method used to deliver the subscription. To remove shipping set this to `null` and the `amount=0`. If `method_id` and `method_code` are both present, `method_id` will be used.</value>
         [JsonProperty("method_code")]

--- a/Recurly/Resources/SubscriptionCreate.cs
+++ b/Recurly/Resources/SubscriptionCreate.cs
@@ -105,7 +105,7 @@ namespace Recurly.Resources
 
         /// <value>Override the unit amount of the subscription plan by setting this value. If not provided, the subscription will inherit the price from the subscription plan for the provided currency.</value>
         [JsonProperty("unit_amount")]
-        public float? UnitAmount { get; set; }
+        public decimal? UnitAmount { get; set; }
 
     }
 }

--- a/Recurly/Resources/SubscriptionPurchase.cs
+++ b/Recurly/Resources/SubscriptionPurchase.cs
@@ -61,7 +61,7 @@ namespace Recurly.Resources
 
         /// <value>Override the unit amount of the subscription plan by setting this value in cents. If not provided, the subscription will inherit the price from the subscription plan for the provided currency.</value>
         [JsonProperty("unit_amount")]
-        public float? UnitAmount { get; set; }
+        public decimal? UnitAmount { get; set; }
 
     }
 }

--- a/Recurly/Resources/SubscriptionShipping.cs
+++ b/Recurly/Resources/SubscriptionShipping.cs
@@ -21,7 +21,7 @@ namespace Recurly.Resources
 
         /// <value>Subscription's shipping cost</value>
         [JsonProperty("amount")]
-        public float? Amount { get; set; }
+        public decimal? Amount { get; set; }
 
 
         [JsonProperty("method")]

--- a/Recurly/Resources/SubscriptionShippingCreate.cs
+++ b/Recurly/Resources/SubscriptionShippingCreate.cs
@@ -25,7 +25,7 @@ namespace Recurly.Resources
 
         /// <value>Assigns the subscription's shipping cost. If this is greater than zero then a `method_id` or `method_code` is required.</value>
         [JsonProperty("amount")]
-        public float? Amount { get; set; }
+        public decimal? Amount { get; set; }
 
         /// <value>The code of the shipping method used to deliver the subscription. If `method_id` and `method_code` are both present, `method_id` will be used.</value>
         [JsonProperty("method_code")]

--- a/Recurly/Resources/SubscriptionShippingPurchase.cs
+++ b/Recurly/Resources/SubscriptionShippingPurchase.cs
@@ -17,7 +17,7 @@ namespace Recurly.Resources
 
         /// <value>Assigns the subscription's shipping cost. If this is greater than zero then a `method_id` or `method_code` is required.</value>
         [JsonProperty("amount")]
-        public float? Amount { get; set; }
+        public decimal? Amount { get; set; }
 
         /// <value>The code of the shipping method used to deliver the subscription. If `method_id` and `method_code` are both present, `method_id` will be used.</value>
         [JsonProperty("method_code")]

--- a/Recurly/Resources/TaxInfo.cs
+++ b/Recurly/Resources/TaxInfo.cs
@@ -17,7 +17,7 @@ namespace Recurly.Resources
 
         /// <value>Rate</value>
         [JsonProperty("rate")]
-        public float? Rate { get; set; }
+        public decimal? Rate { get; set; }
 
         /// <value>Provides the tax region applied on an invoice. For U.S. Sales Tax, this will be the 2 letter state code. For EU VAT this will be the 2 letter country code. For all country level tax types, this will display the regional tax, like VAT, GST, or PST.</value>
         [JsonProperty("region")]

--- a/Recurly/Resources/Transaction.cs
+++ b/Recurly/Resources/Transaction.cs
@@ -21,7 +21,7 @@ namespace Recurly.Resources
 
         /// <value>Total transaction amount sent to the payment gateway.</value>
         [JsonProperty("amount")]
-        public float? Amount { get; set; }
+        public decimal? Amount { get; set; }
 
         /// <value>When processed, result from checking the overall AVS on the transaction.</value>
         [JsonProperty("avs_check")]


### PR DESCRIPTION
I've opened a PR to show what the types should look like when generated to C#.  Floating-point types are not accurate for monetary amounts.  From [Microsoft](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/types#the-decimal-type): 
> The decimal type is a 128-bit data type suitable for financial and monetary calculations. The decimal type can represent values ranging from 1.0 * 10^-28 to approximately 7.9 * 10^28, with 28-29 significant digits.

Additional information on Floating Points can be found here: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/floating-point-numeric-types

You may be able to patch the OpenApi specification, but it officially only supports `number` type up to `double` ([src](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#data-types)).

Additionally, I've patched the tests to work locally regardless of the timezone your machine is in.