### PR TITLE
Enable item-backed add-ons

### DIFF
--- a/Library/AddOn.cs
+++ b/Library/AddOn.cs
@@ -81,34 +81,16 @@ namespace Recurly
         /// <summary>
         /// Update an existing add on in Recurly
         /// </summary>
-        public void Update()
-        {
-            Plan plan = Plans.Get(this.PlanCode);
-            AddOn addon = plan.GetAddOn(this.AddOnCode);
-
+        public void Update() {
             if (this.ItemState == null) {
                 Client.Instance.PerformRequest(Client.HttpRequestMethod.Put,
                     UrlPrefix + Uri.EscapeDataString(PlanCode) + UrlPostfix + Uri.EscapeDataString(AddOnCode),
                     WriteXml,
                     ReadXml);
             } else {
-                // update item-backed add-on
-                AddOn request = new AddOn();
-                if (this.DefaultQuantity != addon.DefaultQuantity) {
-                    request.DefaultQuantity = this.DefaultQuantity;
-                }
-                if (this.UnitAmountInCents["USD"] != addon.UnitAmountInCents["USD"]) {
-                    request.UnitAmountInCents["USD"] = this.UnitAmountInCents["USD"];
-                }
-                if (this.Optional != addon.Optional) {
-                    request.Optional = this.Optional;
-                }
-                if (this.DisplayQuantityOnHostedPage != addon.DisplayQuantityOnHostedPage) {
-                    request.DisplayQuantityOnHostedPage = this.DisplayQuantityOnHostedPage;
-                }
                 Client.Instance.PerformRequest(Client.HttpRequestMethod.Put,
                     UrlPrefix + Uri.EscapeDataString(PlanCode) + UrlPostfix + Uri.EscapeDataString(AddOnCode),
-                    request.WriteXml,
+                    WriteItemBackedUpdateXml,
                     ReadXml);
             }
         }
@@ -256,6 +238,21 @@ namespace Recurly
 
             if (RevenueScheduleType.HasValue)
                 xmlWriter.WriteElementString("revenue_schedule_type", RevenueScheduleType.Value.ToString().EnumNameToTransportCase());
+
+            xmlWriter.WriteEndElement();
+        }
+
+        internal void WriteItemBackedUpdateXml(XmlTextWriter xmlWriter) {
+            xmlWriter.WriteStartElement("add_on");
+
+            if (DefaultQuantity.HasValue)
+                xmlWriter.WriteElementString("default_quantity", DefaultQuantity.Value.AsString());
+            xmlWriter.WriteIfCollectionHasAny("unit_amount_in_cents", UnitAmountInCents, pair => pair.Key,
+                pair => pair.Value.AsString());
+            if (Optional.HasValue)
+                xmlWriter.WriteElementString("optional", Optional.Value.AsString());
+            if (DisplayQuantityOnHostedPage.HasValue)
+                xmlWriter.WriteElementString("display_quantity_on_hosted_page", DisplayQuantityOnHostedPage.Value.AsString());
 
             xmlWriter.WriteEndElement();
         }

--- a/Library/Configuration/Settings.cs
+++ b/Library/Configuration/Settings.cs
@@ -78,7 +78,7 @@ namespace Recurly.Configuration
         }
 
         protected const string RecurlyServerUri = "https://{0}.recurly.com/v2{1}";
-        public const string RecurlyApiVersion = "2.25";
+        public const string RecurlyApiVersion = "2.26";
         public const string ValidDomain = ".recurly.com";
 
         // static, unlikely to change

--- a/Library/Plan.cs
+++ b/Library/Plan.cs
@@ -167,14 +167,12 @@ namespace Recurly
         /// <returns></returns>
         public AddOn NewAddOn(string addOnCode, string name)
         {
-            var a = new AddOn(PlanCode, addOnCode, name);
-            return a;
+            return new AddOn(PlanCode, addOnCode, name);
         }
 
         public AddOn NewAddOn(string itemCode)
         {
-            var a = new AddOn(PlanCode, itemCode);
-            return a;
+            return new AddOn(PlanCode, itemCode);
         }
 
         public AddOn GetAddOn(string addOnCode)

--- a/Library/Plan.cs
+++ b/Library/Plan.cs
@@ -171,6 +171,12 @@ namespace Recurly
             return a;
         }
 
+        public AddOn NewAddOn(string itemCode)
+        {
+            var a = new AddOn(PlanCode, itemCode);
+            return a;
+        }
+
         public AddOn GetAddOn(string addOnCode)
         {
             if (string.IsNullOrWhiteSpace(addOnCode))

--- a/Test/PlanTest.cs
+++ b/Test/PlanTest.cs
@@ -75,6 +75,39 @@ namespace Recurly.Test
         }
 
         [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void CreatePlanWithAddOn()
+        {
+            var plan = new Plan(GetMockPlanCode(), GetMockPlanName());
+            plan.SetupFeeInCents.Add("USD", 500);
+            plan.Create();
+            PlansToDeactivateOnDispose.Add(plan);
+
+            var addon = plan.NewAddOn("add_on", "Add on");
+            addon.UnitAmountInCents.Add("USD", 200);
+            addon.Create();
+
+            plan.AddOns[0].AddOnCode.Should().Be(addon.AddOnCode);
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void CreatePlanWithItemBackedAddOn()
+        {
+            var plan = new Plan(GetMockPlanCode(), GetMockPlanName());
+            plan.SetupFeeInCents.Add("USD", 500);
+            plan.Create();
+            PlansToDeactivateOnDispose.Add(plan);
+
+            var item = new Item(GetMockItemCode(), GetMockItemName());
+            item.Create();
+
+            var addon = plan.NewAddOn(item.ItemCode);
+            addon.UnitAmountInCents.Add("USD", 200);
+            addon.Create();
+
+            addon.ItemCode.Should().Be(item.ItemCode);
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Integration)]
         public void UpdatePlan()
         {
             var plan = new Plan(GetMockPlanCode(), GetMockPlanName()) {Description = "Test Update"};


### PR DESCRIPTION
To create item-backed add-on:
```c#
var addon = plan.NewAddOn("item_code");
addon.UnitAmountInCents.Add("USD", 200);
addon.Create();
```

To get an item-backed-add-on:
```c#
plan.GetAddOn(item.ItemCode);
```

To update item-backed add-on:
```c#
addon.UnitAmountInCents["USD"] = 200;
addon.Update();
```

When add-on has an associated item, only the following attributes are updatable:
```c#
unit_amount_in_cents
default_quantity
display_quantity_on_hosted_page
optional
```