### PR TITLE
Add IBAN attribute to BillingInfo

### DIFF
--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -112,6 +112,8 @@ namespace Recurly
         /// </summary>
         public string ThreeDSecureActionResultTokenId { get; set; }
 
+        public string Iban { get; set; }
+
         public string TransactionType { get; set; }
 
         private string _cardNumber;
@@ -346,6 +348,10 @@ namespace Recurly
                         RoutingNumber = reader.ReadElementContentAsString();
                         break;
 
+                    case "iban":
+                        Iban = reader.ReadElementContentAsString();
+                        break;
+
                     case "account_type":
 
                         var accountType = reader.ReadElementContentAsString();
@@ -414,6 +420,10 @@ namespace Recurly
                     xmlWriter.WriteElementString("account_type", AccountType.ToString().EnumNameToTransportCase());
                 }
 
+                if (!Iban.IsNullOrEmpty())
+                {
+                    xmlWriter.WriteElementString("iban", Iban);
+                }
                 if (!PaypalBillingAgreementId.IsNullOrEmpty())
                 {
                     xmlWriter.WriteElementString("paypal_billing_agreement_id", PaypalBillingAgreementId);

--- a/Library/Configuration/Settings.cs
+++ b/Library/Configuration/Settings.cs
@@ -78,7 +78,7 @@ namespace Recurly.Configuration
         }
 
         protected const string RecurlyServerUri = "https://{0}.recurly.com/v2{1}";
-        public const string RecurlyApiVersion = "2.25";
+        public const string RecurlyApiVersion = "2.26";
         public const string ValidDomain = ".recurly.com";
 
         // static, unlikely to change

--- a/Test/BillingInfoTest.cs
+++ b/Test/BillingInfoTest.cs
@@ -88,6 +88,29 @@ namespace Recurly.Test
         }
 
         [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void CreateBillingInfoWithIban()
+        {
+            var account2 = CreateNewAccount();
+            var ibanInfo = new BillingInfo(account2)
+            {
+                NameOnAccount = "Iban account name",
+                Iban = "FR1420041010050500013M02606",
+                Address1 = "123 Test St",
+                Address2 = "The Test Cut",
+                City = "San Francisco",
+                PostalCode = "94105",
+                State = "CA",
+                Country = "US",
+            };
+            try {
+                ibanInfo.Create();
+            } catch (ValidationException exception) {
+                System.Console.WriteLine(exception);
+            }
+            account2.BillingInfo.NameOnAccount.Should().Be("Iban account name");
+        }
+            
+        [RecurlyFact(TestEnvironment.Type.Integration)]
         public void LookupBillingInfo()
         {
             var accountCode = GetUniqueAccountCode();


### PR DESCRIPTION
This feature is to allow support of the IBAN field in our V2 API for the applicable endpoints. This field is most similar to banking account information or credit card information, and is used to make payments for SEPA transactions.

IBAN numbers can be set in all endpoints that support BillingInfo:

PUT "/v2/accounts/{account_id}/billing_info"
PUT "/v2/accounts/{account_id}"
POST "/v2/accounts"
POST "/v2/subscriptions"
POST "/v2/purchases"
POST "/v2/purchases/preview"

A sample request payload is provided below:

```
<billing_info>
  <iban>IBANNUMBERHERE</iban>
  <name_on_account>Verena Example</name_on_account>
  <!-- address fields... ->
</billing_info>
```