### PR TITLE
Adding #First and #Count methods to Pager

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,39 @@ var accounts = client.ListAccounts(
 );
 ```
 
+#### Additional Pager Methods
+
+In addition to the methods to facilitate pagination, the Pager class provides 2 helper methods:
+
+1. First
+2. Count
+
+##### First
+
+The Pager's `First` method can be used to fetch only the first resource from the endpoint for the given parameters.
+
+```csharp
+var beginTime = new DateTime(2020, 1, 1);
+var accounts = client.ListAccounts(
+    beginTime: beginTime
+);
+var account = accounts.First();
+Console.WriteLine(account.Code);
+```
+
+##### Count
+
+The Pager's `Count` method will return the total number of resources that are available at the requested endpoint for the given parameters.
+
+```csharp
+var beginTime = new DateTime(2020, 1, 1);
+var accounts = client.ListAccounts(
+    beginTime: beginTime
+);
+var total = accounts.Count();
+Console.WriteLine($"There are {total} accounts created since {beginTime}");
+```
+
 ### Creating Resources
 
 Every `Create*` or `Update*` method on the client takes a specific Request type to form the request.

--- a/Recurly/BaseClient.cs
+++ b/Recurly/BaseClient.cs
@@ -69,6 +69,19 @@ namespace Recurly
             return resp.Data;
         }
 
+        public int GetResourceCount(string url)
+        {
+            Debug.WriteLine($"Calling {url}");
+            var request = BuildRequest(Method.HEAD, url, null, null);
+            var resp = RestClient.Execute(request);
+            this.HandleResponse(resp);
+            var headers = resp.Headers.ToList();
+            var recordCount = headers
+                .Find(x => x.Name == "Recurly-Total-Records")
+                .Value.ToString();
+            return int.Parse(recordCount);
+        }
+
         public void _SetApiUrl(string uri)
         {
             Console.WriteLine("[SECURITY WARNING] _SetApiUrl is for testing only and not supported in production.");


### PR DESCRIPTION
Adds the `First` and `Count` methods to the `Pager` class.

The `First` method will perform a request to the API with the `limit` set to 1 and will only return the first result from the server.

The `Count` method will perform a `HEAD` request to the API for the appropriate endpoint. The value of the response header, `recurly-total-records`, will be returned. This is the total number of records that will be returned by the pager.