### PR TITLE
Add tier_type to SubscriptionAddOn and related constructor

### DIFF
--- a/Library/AddOn.cs
+++ b/Library/AddOn.cs
@@ -26,7 +26,7 @@ namespace Recurly
         public DateTime CreatedAt { get; private set; }
         public DateTime UpdatedAt { get; private set; }
         public Adjustment.RevenueSchedule? RevenueScheduleType { get; set; }
-        public string TierType {get; set; }
+        public string TierType { get; set; }
 
         private List<Tier> _tiers; 
 

--- a/Library/List/SubscriptionAddOnList.cs
+++ b/Library/List/SubscriptionAddOnList.cs
@@ -105,6 +105,25 @@ namespace Recurly
             base.Add(sub);
         }
 
+        /// <summary>
+        /// Adds the given tiered-pricing <see cref="T:Recurly.AddOn"/> to the current Subscription.
+        /// 
+        /// Sample usage:
+        /// <code>
+        /// sub.AddOns.Add(planAddOn, tierType, quantity)
+        /// sub.AddOns.Add(planAddOn, tierType) // default quantity = 1
+        /// </code>
+        /// </summary>
+        /// <param name="planAddOn">The <see cref="T:Recurly.AddOn"/> to add to the current Subscription.</param>
+        /// <param name="tierType">The add-on tier-type.</param>
+        /// <param name="quantity">The quantity of the add-on. Optional, default is 1.</param>
+
+        public void Add(AddOn planAddOn, string tierType, int quantity)
+        {
+            var sub = new SubscriptionAddOn(planAddOn.AddOnCode, tierType, quantity);
+            base.Add(sub);
+        }
+
         // sub.AddOns.Add(code, quantity, unitInCents);
         // sub.AddOns.Add(code, quantity); unitInCents=this.Plan.UnitAmountInCents[this.Currency]
         // sub.AddOns.Add(code); 1, unitInCents=this.Plan.UnitAmountInCents[this.Currency]

--- a/Library/SubscriptionAddOn.cs
+++ b/Library/SubscriptionAddOn.cs
@@ -12,6 +12,7 @@ namespace Recurly
         public int Quantity { get; set; }
         public Adjustment.RevenueSchedule? RevenueScheduleType { get; set; }
         public float? UsagePercentage { get; set; }
+        public string TierType { get; set; }
 
         public SubscriptionAddOn(XmlTextReader reader)
         {
@@ -32,6 +33,14 @@ namespace Recurly
             AddOnCode = addOnCode;
             AddOnType = addOnType;
             UnitAmountInCents = unitAmountInCents;
+            Quantity = quantity;
+        }
+
+        // new constructor for tiered-pricing
+        public SubscriptionAddOn(string addOnCode, string tierType, int quantity = 1)
+        {
+            AddOnCode = addOnCode;
+            TierType = tierType;
             Quantity = quantity;
         }
 
@@ -76,6 +85,11 @@ namespace Recurly
                                 CultureInfo.InvariantCulture.NumberFormat, out float percentage))
                             UsagePercentage = percentage;
                         break;
+
+                    case "tier_type":
+                        TierType = reader.ReadElementContentAsString();
+                        break;
+
                 }
             }
         }
@@ -95,6 +109,9 @@ namespace Recurly
 
             if (UsagePercentage.HasValue)
                 writer.WriteElementString("usage_percentage", UsagePercentage.ToString());
+
+            if (TierType != null)
+                writer.WriteElementString("tier_type", TierType);
 
             writer.WriteEndElement();
         }


### PR DESCRIPTION
To create subscription with tiered-pricing add-on:
```c#
var addon = plan.NewAddOn("tiered-add-on", "Tiered Add-On"); // add-on code, name
addon.TierType = "tiered";

var tier = new Tier();
tier.UnitAmountInCents.Add("USD", 123);
tier.EndingQuantity = 60;
addon.Tiers.Add(tier);

var anotherTier = new Tier();
anotherTier.UnitAmountInCents.Add("USD", 80);
addon.Tiers.Add(anotherTier);

addon.Create();

var subscription = new Subscription(account, plan, "USD"); // account, plan, currency
subscription.AddOns.Add(plan.GetAddOn(addon.AddOnCode), addon.TierType); // addon, tier type, quantity (optional, defaults to 1)


subscription.Create();
```