### PR TITLE
Add mandate_reference attribute to BillingInfo

### DIFF
--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -41,6 +41,7 @@ namespace Recurly
         public string AccountCode { get; private set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
+        public string MandateReference { get; set; }
         public string Address1 { get; set; }
         public string Address2 { get; set; }
         public string City { get; set; }
@@ -256,6 +257,10 @@ namespace Recurly
                         LastName = reader.ReadElementContentAsString();
                         break;
 
+                    case "mandate_reference":
+                        MandateReference = reader.ReadElementContentAsString();
+                        break;
+
                     case "name_on_account":
                         NameOnAccount = reader.ReadElementContentAsString();
                         break;
@@ -381,6 +386,7 @@ namespace Recurly
             {
                 xmlWriter.WriteStringIfValid("first_name", FirstName);
                 xmlWriter.WriteStringIfValid("last_name", LastName);
+                xmlWriter.WriteStringIfValid("mandate_reference", MandateReference);
                 xmlWriter.WriteStringIfValid("company", Company);
                 xmlWriter.WriteStringIfValid("name_on_account", NameOnAccount);
                 xmlWriter.WriteStringIfValid("address1", Address1);


### PR DESCRIPTION
A mandate reference is a specific ID used in a payment system to show that an agreement was made between the customer and the merchant. It is often required for compliance reasons to display when a billing info is created or a payment is created.