### PR TITLE
Release 1.17.3

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,16 @@
 Unreleased
 ===============
 
+1.17.3 (stable) / 2020-03-26
+===============
+
+This brings us up to API version 2.26. There are no breaking changes.
+
+- Add IBAN attribute to BillingInfo [PR](https://github.com/recurly/recurly-client-dotnet/pull/490)
+- Tiered Pricing [PR](https://github.com/recurly/recurly-client-dotnet/pull/496)
+- Add tier_type to SubscriptionAddOn and related constructor [PR](https://github.com/recurly/recurly-client-dotnet/pull/497)
+- Add mandate_reference attribute to BillingInfo [PR](https://github.com/recurly/recurly-client-dotnet/pull/499)
+
 1.17.2 (stable) / 2020-02-20
 ===============
 

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.17.2.0")]
-[assembly: AssemblyFileVersion("1.17.2.0")]
+[assembly: AssemblyVersion("1.17.3.0")]
+[assembly: AssemblyFileVersion("1.17.3.0")]

--- a/dist/recurly.nuspec
+++ b/dist/recurly.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>recurly-api-client</id>
-    <version>1.17.2</version>
+    <version>1.17.3</version>
     <authors>recurly</authors>
     <owners>recurly</owners>
     <licenseUrl>https://github.com/recurly/recurly-client-net/blob/master/LICENSE.txt</licenseUrl>


### PR DESCRIPTION
This brings us up to API version 2.26. There are no breaking changes.

- Add IBAN attribute to BillingInfo [PR](https://github.com/recurly/recurly-client-dotnet/pull/490)
- Tiered Pricing [PR](https://github.com/recurly/recurly-client-dotnet/pull/496)
- Add tier_type to SubscriptionAddOn and related constructor [PR](https://github.com/recurly/recurly-client-dotnet/pull/497)
- Add mandate_reference attribute to BillingInfo [PR](https://github.com/recurly/recurly-client-dotnet/pull/499)