### PR TITLE
Release 1.17.4

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,12 @@
 Unreleased
 ===============
 
+1.17.4 (stable) / 2020-04-15
+===============
+
+- Enable item-backed add-ons [PR](https://github.com/recurly/recurly-client-dotnet/pull/489)
+- Allow tiered add-ons to be updated [PR](https://github.com/recurly/recurly-client-dotnet/pull/503)
+
 1.17.3 (stable) / 2020-03-26
 ===============
 

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.17.3.0")]
-[assembly: AssemblyFileVersion("1.17.3.0")]
+[assembly: AssemblyVersion("1.17.4.0")]
+[assembly: AssemblyFileVersion("1.17.4.0")]

--- a/dist/recurly.nuspec
+++ b/dist/recurly.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>recurly-api-client</id>
-    <version>1.17.3</version>
+    <version>1.17.4</version>
     <authors>recurly</authors>
     <owners>recurly</owners>
     <licenseUrl>https://github.com/recurly/recurly-client-net/blob/master/LICENSE.txt</licenseUrl>


### PR DESCRIPTION
- Enable item-backed add-ons [PR](https://github.com/recurly/recurly-client-dotnet/pull/489)
- Allow tiered add-ons to be updated [PR](https://github.com/recurly/recurly-client-dotnet/pull/503)