### PR TITLE
Ensure that path parameters are not empty strings

### DIFF
--- a/Recurly.Tests/BaseClientTest.cs
+++ b/Recurly.Tests/BaseClientTest.cs
@@ -93,6 +93,14 @@ namespace Recurly.Tests
         }
 
         [Fact]
+        public void WillValidatePathParams()
+        {
+            var client = this.GetResourceSuccessClient();
+            MyResource resource = client.GetResource("benjamin", "param1", new DateTime(2020, 01, 01));
+            Assert.Throws<Recurly.RecurlyError>(() => client.GetResource("", "param1", new DateTime(2020, 01, 01)));
+        }
+
+        [Fact]
         public void WillThrowNotFoundExceptionForNon200()
         {
             var client = this.GetResourceFailureClient();

--- a/Recurly/BaseClient.cs
+++ b/Recurly/BaseClient.cs
@@ -164,8 +164,20 @@ namespace Recurly
             }
         }
 
+        private void ValidatePathParameters(Dictionary<string, object> urlParams)
+        {
+            var invalidParams = urlParams.Where(kvp => string.IsNullOrWhiteSpace(kvp.Value.ToString()));
+            if (invalidParams.Any())
+            {
+                var invalidKeys = string.Join(", ", invalidParams.Select(x => x.Key).ToArray());
+                throw new RecurlyError($"{invalidKeys} cannot be an empty value");
+            }
+
+        }
+
         protected string InterpolatePath(string path, Dictionary<string, object> urlParams)
         {
+            ValidatePathParameters(urlParams);
             var regex = new Regex("{([A-Za-z|_]*)}");
             // TODO ToString() here might not appropriately format all data types
             // such as datetimes


### PR DESCRIPTION
Adding a validation method that will ensure that path parameters are not empty strings to address issues where a `get_*` operation (`/resources/{resource_id}`) does not get handled by the API as a `list_*` operations (`/resources/`).