### PR TITLE
Bugfix: Unexpected character encountered while parsing value: "{"

### DIFF
--- a/Recurly/Resources/Transaction.cs
+++ b/Recurly/Resources/Transaction.cs
@@ -81,7 +81,7 @@ namespace Recurly.Resources
 
         /// <value>The values in this field will vary from gateway to gateway.</value>
         [JsonProperty("gateway_response_values")]
-        public Dictionary<string, string> GatewayResponseValues { get; set; }
+        public Dictionary<string, object> GatewayResponseValues { get; set; }
 
         /// <value>Transaction ID</value>
         [JsonProperty("id")]


### PR DESCRIPTION
Fixes a parsing bug when the unstructured objects in JSON have nested objects:

```
Newtonsoft.Json.JsonReaderException: Unexpected character encountered while parsing value: {. Path 'charge_invoice.transactions[0].gateway_response_values.card_country', line 1, position 3686
```

As this is a bugfix and not working as intended, we are considering releasing this as a patch level change even though it technically may require changes on the programmer's end. The scope should just be limited to the`Transaction#GatewayResponseValues` property so we cause as little disruption to existing use as possible.

### Follow up

In v4 we should consider switching these dynamic objects into something that the framework supports as Dictionaries are pretty cumbersome in csharp. Perhaps this object: https://docs.microsoft.com/en-us/dotnet/api/system.text.json.jsondocument?view=netcore-3.0

I'd consider passing back the dynamic JSON object we get from JSON.net, but i do not want to expose the dependencies to the programmer in case we wish to change or remove them in the future.