### PR TITLE
Update serializer for item-backed add-ons to accommodate QBP

### DIFF
--- a/Library/AddOn.cs
+++ b/Library/AddOn.cs
@@ -29,7 +29,16 @@ namespace Recurly
         public DateTime UpdatedAt { get; private set; }
         public Adjustment.RevenueSchedule? RevenueScheduleType { get; set; }
         public string ItemState { get; set; }
-        public string TierType { get; set; }
+        private string _tierType;
+        public string TierType { 
+          get
+          {
+            return (_tierType == null) ? "flat" : _tierType;
+          }
+          set {
+            _tierType = value;
+          }
+        }
 
         private List<Tier> _tiers; 
 
@@ -221,7 +230,7 @@ namespace Recurly
         internal override void WriteXml(XmlTextWriter xmlWriter)
         {
             xmlWriter.WriteStartElement("add_on");
-            
+
             xmlWriter.WriteStringIfValid("item_code", ItemCode);
             xmlWriter.WriteStringIfValid("add_on_code", AddOnCode);
             xmlWriter.WriteStringIfValid("name", Name);
@@ -248,15 +257,14 @@ namespace Recurly
             if (Optional.HasValue)
                 xmlWriter.WriteElementString("optional", Optional.Value.AsString());
 
-            if (this.TierType == "flat")
+            if (TierType == "flat")
                 xmlWriter.WriteIfCollectionHasAny("unit_amount_in_cents", UnitAmountInCents, pair => pair.Key,
                     pair => pair.Value.AsString());
 
             if (RevenueScheduleType.HasValue)
                 xmlWriter.WriteElementString("revenue_schedule_type", RevenueScheduleType.Value.ToString().EnumNameToTransportCase());
 
-            if (TierType != null)
-                xmlWriter.WriteElementString("tier_type", TierType);
+            xmlWriter.WriteElementString("tier_type", TierType);
 
             xmlWriter.WriteIfCollectionHasAny("tiers", Tiers);
 
@@ -268,12 +276,15 @@ namespace Recurly
 
             if (DefaultQuantity.HasValue)
                 xmlWriter.WriteElementString("default_quantity", DefaultQuantity.Value.AsString());
-            xmlWriter.WriteIfCollectionHasAny("unit_amount_in_cents", UnitAmountInCents, pair => pair.Key,
-                pair => pair.Value.AsString());
+            if (TierType == "flat")
+                xmlWriter.WriteIfCollectionHasAny("unit_amount_in_cents", UnitAmountInCents, pair => pair.Key,
+                    pair => pair.Value.AsString());
             if (Optional.HasValue)
                 xmlWriter.WriteElementString("optional", Optional.Value.AsString());
             if (DisplayQuantityOnHostedPage.HasValue)
                 xmlWriter.WriteElementString("display_quantity_on_hosted_page", DisplayQuantityOnHostedPage.Value.AsString());
+            xmlWriter.WriteElementString("tier_type", TierType);
+            xmlWriter.WriteIfCollectionHasAny("tiers", Tiers);
 
             xmlWriter.WriteEndElement();
         }

--- a/Test/AddOnTest.cs
+++ b/Test/AddOnTest.cs
@@ -23,7 +23,7 @@ namespace Recurly.Test
       addon.DefaultQuantity.Value.Should().Be(1);
     }
 
-        [RecurlyFact(TestEnvironment.Type.Integration)]
+    [RecurlyFact(TestEnvironment.Type.Integration)]
     public void CreateAddOnWithTiers()
     {
       var plan = new Plan(GetMockPlanCode(), GetMockPlanName()) {Description = "Test Lookup"};
@@ -33,6 +33,7 @@ namespace Recurly.Test
 
       var addon = plan.NewAddOn("extra-padding", "Extra Padding");
       addon.TierType = "tiered";
+      addon.DisplayQuantityOnHostedPage = true;
       var tier = new Tier();
       tier.UnitAmountInCents.Add("USD", 100);
       tier.EndingQuantity = 60;
@@ -43,6 +44,34 @@ namespace Recurly.Test
       addon.Create();
 
       addon.Tiers.Count.Should().Be(2);
+    }
+
+    [RecurlyFact(TestEnvironment.Type.Integration)]
+    public void UpdateAddOn()
+    {
+      var plan = new Plan(GetMockPlanCode(), GetMockPlanName()) {Description = "Test Lookup"};
+      plan.UnitAmountInCents.Add("USD", 100);
+      plan.Create();
+      PlansToDeactivateOnDispose.Add(plan);
+
+      var addon = plan.NewAddOn("extra-padding", "Extra Padding");
+      addon.TierType = "tiered";
+      addon.DisplayQuantityOnHostedPage = true;
+      var tier = new Tier();
+      tier.UnitAmountInCents.Add("USD", 100);
+      tier.EndingQuantity = 60;
+      addon.Tiers.Add(tier);
+      var anotherTier = new Tier();
+      anotherTier.UnitAmountInCents.Add("USD", 50);
+      addon.Tiers.Add(anotherTier);
+      addon.Create();
+
+      addon.Name = "Deluxe Padding";
+      addon.Tiers[0].UnitAmountInCents["USD"] = 75;
+      addon.Update();
+
+      addon.Name.Should().Be("Deluxe Padding");
+      addon.Tiers[0].UnitAmountInCents.Should().Contain("USD", 75);
     }
 
   }


### PR DESCRIPTION
**For item-backed QBP add-ons:**
This PR changes the [serializer for item-backed add-ons](https://ci-master.dev-inf.recurly.net/blue/organizations/jenkins/recurly-github%2Frecurly-app/detail/PR-15610-head/5/pipeline) to include quantity-based pricing tiers. 

**For general QBP add-ons:**
A previous [PR](https://github.com/recurly/recurly-client-dotnet/pull/503/files) considered cases where `TierType == flat`. This allows us to update add-ons by only including the `unit_amount_in_cents ` element in the absence of QBP. Otherwise, `unit_amount_in_cents` is [included within `Tier`](https://github.com/recurly/recurly-client-net/blob/f8ca4960b4b70570bddd559f70d3117f8f1bfc6d/Library/Tier.cs#L81-L83).

To handle the case where the user may not explicitly set `TierType` to `flat` when creating an add-on, we configure get and set accessors to set the default value for `TierType` to "flat". When creating a QBP add-on, `TierType` is required and will throw an error when one is not provided.