### PR TITLE
Ignore errors in build script

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -e
 
 if ! test -f "./bin/dotnet-format"; then
   echo "Installing dotnet formatter..."


### PR DESCRIPTION
```
Installing dotnet formatter...
Tool 'dotnet-format' is already installed.
```

set -e it seems if dotnet is installed already, that command exits with
a bad status. This kills the whole script (keeping it from running build)