### PR TITLE
Applying query params to url before creating the request

### DIFF
--- a/Recurly.Tests/BaseClientTest.cs
+++ b/Recurly.Tests/BaseClientTest.cs
@@ -53,6 +53,20 @@ namespace Recurly.Tests
         }
 
         [Fact]
+        public void WillAddQueryStringParameters()
+        {
+            var date = new DateTime(2020, 01, 01);
+            var paramsMatcher = MockClient.ParameterMatcher(new Dictionary<string, object> {
+                { "param_1", "param1" },
+                { "param_2", Recurly.Utils.ISO8601(date) },
+            });
+
+            var client = MockClient.Build(paramsMatcher, SuccessResponse(System.Net.HttpStatusCode.OK));
+            MyResource resource = client.GetResource("benjamin", "param1", date);
+            Assert.Equal("benjamin", resource.MyString);
+        }
+
+        [Fact]
         public void WillValidatePathParams()
         {
             var client = MockClient.Build(SuccessResponse(System.Net.HttpStatusCode.OK));

--- a/Recurly/BaseClient.cs
+++ b/Recurly/BaseClient.cs
@@ -97,14 +97,14 @@ namespace Recurly
 
         private RestRequest BuildRequest(Method method, string url, Request body = null, Dictionary<string, object> queryParams = null)
         {
-            var request = new RestRequest(url, method);
-            request.JsonSerializer = Recurly.JsonSerializer.Default;
-
             // If we have any query params, add them to the request
             if (queryParams != null)
             {
                 url += Utils.QueryString(queryParams);
             }
+
+            var request = new RestRequest(url, method);
+            request.JsonSerializer = Recurly.JsonSerializer.Default;
 
             // If we have a body, serialize it and add it to the request
             if (body != null)


### PR DESCRIPTION
Query parameters were not being applied to the url properly when generating the request. 