### PR TITLE
Adding MockClient and refactoring tests to use it

### DIFF
--- a/Recurly.Tests/BaseClientTest.cs
+++ b/Recurly.Tests/BaseClientTest.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
-using Xunit;
-using RestSharp;
 using Moq;
+using RestSharp;
+using Xunit;
 
 namespace Recurly.Tests
 {

--- a/Recurly.Tests/BaseClientTest.cs
+++ b/Recurly.Tests/BaseClientTest.cs
@@ -1,73 +1,33 @@
 using System;
-using System.Threading.Tasks;
-using System.Collections;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
-using System.Linq;
 using Xunit;
-using Recurly;
-using Recurly.Resources;
 using RestSharp;
-using RestSharp.Authenticators;
 using Moq;
-using System.Threading;
 
 namespace Recurly.Tests
 {
     public class BaseClientTest
     {
-        private string apiKey = "myapikey";
-
-        internal class MyClient : BaseClient
-        {
-            public override string ApiVersion => "v2018-08-09";
-
-            public MyClient(string apiKey) : base(apiKey) { }
-
-            public MyResource CreateResource(MyResourceCreate body)
-            {
-                var urlParams = new Dictionary<string, object> { };
-                var url = this.InterpolatePath("/my_resources", urlParams);
-                return MakeRequest<MyResource>(Method.POST, url, body, null);
-            }
-
-            public MyResource GetResource(string resourceId, string param1, DateTime param2)
-            {
-                var urlParams = new Dictionary<string, object> { { "resource_id", resourceId } };
-                var queryParams = new Dictionary<string, object> { { "param_1", param1 }, { "param_2", param2 } };
-                var url = this.InterpolatePath("/my_resources/{resource_id}", urlParams);
-                return MakeRequest<MyResource>(Method.GET, url, null, queryParams);
-            }
-
-            public Task<MyResource> GetResourceAsync(string resourceId, string param1, DateTime param2)
-            {
-                var urlParams = new Dictionary<string, object> { { "resource_id", resourceId } };
-                var queryParams = new Dictionary<string, object> { { "param_1", param1 }, { "param_2", param2 } };
-                var url = this.InterpolatePath("/my_resources/{resource_id}", urlParams);
-                return MakeRequestAsync<MyResource>(Method.GET, url, null, queryParams);
-            }
-        }
-
         public BaseClientTest() { }
 
         [Fact]
         public void CantInitializeWithoutApiKey()
         {
-            Assert.Throws<ArgumentException>(() => new MyClient(null));
-            Assert.Throws<ArgumentException>(() => new MyClient(""));
+            Assert.Throws<ArgumentException>(() => new MockClient(null));
+            Assert.Throws<ArgumentException>(() => new MockClient(""));
         }
 
         [Fact]
         public void RespondsWithGivenApiVersion()
         {
-            var client = new MyClient(apiKey);
+            var client = new MockClient("myapikey");
             Assert.Equal("v2018-08-09", client.ApiVersion);
         }
 
         [Fact]
         public void CanProperlyFetchAResource()
         {
-            var client = this.MockResourceClient(SuccessResponse(System.Net.HttpStatusCode.OK));
+            var client = MockClient.Build(SuccessResponse(System.Net.HttpStatusCode.OK));
             MyResource resource = client.GetResource("benjamin", "param1", new DateTime(2020, 01, 01));
             Assert.Equal("benjamin", resource.MyString);
         }
@@ -75,7 +35,7 @@ namespace Recurly.Tests
         [Fact]
         public async void CanProperlyFetchAResourceAsync()
         {
-            var client = this.MockResourceClient(SuccessResponse(System.Net.HttpStatusCode.OK));
+            var client = MockClient.Build(SuccessResponse(System.Net.HttpStatusCode.OK));
             MyResource resource = await client.GetResourceAsync("benjamin", "param1", new DateTime(2020, 01, 01));
             Assert.Equal("benjamin", resource.MyString);
         }
@@ -83,7 +43,7 @@ namespace Recurly.Tests
         [Fact]
         public void CanProperlyCreateAResource()
         {
-            var client = this.MockResourceClient(SuccessResponse(System.Net.HttpStatusCode.Created));
+            var client = MockClient.Build(SuccessResponse(System.Net.HttpStatusCode.Created));
             var request = new MyResourceCreate()
             {
                 MyString = "benjamin"
@@ -95,7 +55,7 @@ namespace Recurly.Tests
         [Fact]
         public void WillValidatePathParams()
         {
-            var client = this.MockResourceClient(SuccessResponse(System.Net.HttpStatusCode.OK));
+            var client = MockClient.Build(SuccessResponse(System.Net.HttpStatusCode.OK));
             MyResource resource = client.GetResource("benjamin", "param1", new DateTime(2020, 01, 01));
             Assert.Throws<Recurly.RecurlyError>(() => client.GetResource("", "param1", new DateTime(2020, 01, 01)));
         }
@@ -108,21 +68,21 @@ namespace Recurly.Tests
                 Assert.Equal("/my_resources/douglas%2F", request.Resource);
                 return true;
             };
-            var client = this.MockResourceClient(matcher, NotFoundResponse());
+            var client = MockClient.Build(matcher, NotFoundResponse());
             Assert.Throws<Recurly.Errors.NotFound>(() => client.GetResource("douglas/", "param1", new DateTime(2020, 01, 01)));
         }
 
         [Fact]
         public void WillThrowNotFoundExceptionForNon200()
         {
-            var client = this.MockResourceClient(NotFoundResponse());
+            var client = MockClient.Build(NotFoundResponse());
             Assert.Throws<Recurly.Errors.NotFound>(() => client.GetResource("benjamin", "param1", new DateTime(2020, 01, 01)));
         }
 
         [Fact]
         public void WillThrowAnExceptionWhenResponseHasErrorException()
         {
-            var client = this.MockResourceClient(ErroredResponse());
+            var client = MockClient.Build(ErroredResponse());
             Assert.Throws<Recurly.RecurlyError>(() => client.GetResource("benjamin", "param1", new DateTime(2020, 01, 01)));
         }
 
@@ -161,32 +121,6 @@ namespace Recurly.Tests
             response.Setup(_ => _.Headers).Returns(new List<Parameter> { });
 
             return response;
-        }
-
-        private MyClient MockResourceClient(Mock<IRestResponse<MyResource>> response)
-        {
-            Func<IRestRequest, bool> matcher = delegate (IRestRequest request)
-            {
-                return true;
-            };
-            return MockResourceClient(matcher, response);
-        }
-
-        private MyClient MockResourceClient(Func<IRestRequest, bool> matcher, Mock<IRestResponse<MyResource>> response)
-        {
-            var mockIRestClient = new Mock<IRestClient>();
-            mockIRestClient
-                .Setup(x => x.Execute<MyResource>(It.Is<RestRequest>(r => matcher(r))))
-                .Returns(response.Object);
-
-            mockIRestClient
-                .Setup(x => x.ExecuteTaskAsync<MyResource>(It.Is<IRestRequest>(r => matcher(r)), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(response.Object));
-
-            return new MyClient(apiKey)
-            {
-                RestClient = mockIRestClient.Object
-            };
         }
     }
 }

--- a/Recurly.Tests/ClientTest.cs
+++ b/Recurly.Tests/ClientTest.cs
@@ -1,14 +1,14 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using System.Linq;
-using Xunit;
+using System.Text.RegularExpressions;
+using Moq;
 using Recurly;
 using Recurly.Resources;
 using RestSharp;
 using RestSharp.Authenticators;
-using Moq;
+using Xunit;
 
 namespace Recurly.Tests
 {

--- a/Recurly.Tests/Errors/ApiErrorTest.cs
+++ b/Recurly.Tests/Errors/ApiErrorTest.cs
@@ -1,7 +1,7 @@
-using Xunit;
-using Recurly;
-using Newtonsoft.Json;
 using System;
+using Newtonsoft.Json;
+using Recurly;
+using Xunit;
 
 namespace Recurly.Tests
 {

--- a/Recurly.Tests/JsonSerializerTest.cs
+++ b/Recurly.Tests/JsonSerializerTest.cs
@@ -1,15 +1,15 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 using System.Linq;
-using Xunit;
+using System.Text.RegularExpressions;
+using Moq;
+using Newtonsoft.Json;
 using Recurly;
 using Recurly.Resources;
 using RestSharp;
 using RestSharp.Authenticators;
-using Moq;
-using Newtonsoft.Json;
+using Xunit;
 
 namespace Recurly.Tests
 {

--- a/Recurly.Tests/MockClient.cs
+++ b/Recurly.Tests/MockClient.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using RestSharp;
+using Moq;
+using System.Threading;
+using Xunit;
+
+namespace Recurly.Tests
+{
+    public class MockClient : BaseClient
+    {
+        public override string ApiVersion => "v2018-08-09";
+
+        public MockClient(string apiKey) : base(apiKey) { }
+
+        internal static MockClient Build<T>(Mock<IRestResponse<T>> response, string apiKey = "myapikey")
+        {
+            Func<IRestRequest, bool> matcher = delegate (IRestRequest request)
+            {
+                return true;
+            };
+            var collection = new Dictionary<Func<IRestRequest, bool>, Mock<IRestResponse<T>>> {
+                { matcher, response }
+            };
+            return Build<T>(collection, apiKey);
+        }
+
+        internal static MockClient Build<T>(Func<IRestRequest, bool> matcher, Mock<IRestResponse<T>> response, string apiKey = "myapikey")
+        {
+            var collection = new Dictionary<Func<IRestRequest, bool>, Mock<IRestResponse<T>>> {
+                { matcher, response }
+            };
+            return Build<T>(collection, apiKey);
+        }
+
+        internal static MockClient Build<T>(Dictionary<Func<IRestRequest, bool>, Mock<IRestResponse<T>>> collection, string apiKey = "myapikey")
+        {
+            var mockIRestClient = new Mock<IRestClient>();
+            foreach (KeyValuePair<Func<IRestRequest, bool>, Mock<IRestResponse<T>>> item in collection)
+            {
+                mockIRestClient
+                    .Setup(x => x.Execute<T>(It.Is<RestRequest>(r => item.Key(r))))
+                    .Returns(item.Value.Object);
+
+                mockIRestClient
+                    .Setup(x => x.ExecuteTaskAsync<T>(It.Is<IRestRequest>(r => item.Key(r)), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(item.Value.Object));
+            }
+
+            return new MockClient(apiKey)
+            {
+                RestClient = mockIRestClient.Object
+            };
+        }
+
+        internal static Func<IRestRequest, bool> ParameterMatcher(Dictionary<string, object> expectedParams)
+        {
+            return delegate (IRestRequest request)
+            {
+                Assert.Equal(request.Parameters.Count, expectedParams.Count);
+                foreach (Parameter p in request.Parameters)
+                {
+                    Assert.True(expectedParams.ContainsKey(p.Name));
+                    Assert.Equal(expectedParams[p.Name], p.Value);
+                }
+                return true;
+            };
+        }
+
+        public MyResource CreateResource(MyResourceCreate body)
+        {
+            var urlParams = new Dictionary<string, object> { };
+            var url = this.InterpolatePath("/my_resources", urlParams);
+            return MakeRequest<MyResource>(Method.POST, url, body, null);
+        }
+
+        public MyResource GetResource(string resourceId, string param1, DateTime param2)
+        {
+            var urlParams = new Dictionary<string, object> { { "resource_id", resourceId } };
+            var queryParams = new Dictionary<string, object> { { "param_1", param1 }, { "param_2", param2 } };
+            var url = this.InterpolatePath("/my_resources/{resource_id}", urlParams);
+            return MakeRequest<MyResource>(Method.GET, url, null, queryParams);
+        }
+
+        public Task<MyResource> GetResourceAsync(string resourceId, string param1, DateTime param2)
+        {
+            var urlParams = new Dictionary<string, object> { { "resource_id", resourceId } };
+            var queryParams = new Dictionary<string, object> { { "param_1", param1 }, { "param_2", param2 } };
+            var url = this.InterpolatePath("/my_resources/{resource_id}", urlParams);
+            return MakeRequestAsync<MyResource>(Method.GET, url, null, queryParams);
+        }
+    }
+}

--- a/Recurly.Tests/MockClient.cs
+++ b/Recurly.Tests/MockClient.cs
@@ -1,9 +1,9 @@
 using System;
-using System.Threading.Tasks;
 using System.Collections.Generic;
-using RestSharp;
-using Moq;
 using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using RestSharp;
 using Xunit;
 
 namespace Recurly.Tests

--- a/Recurly.Tests/PagerTest.cs
+++ b/Recurly.Tests/PagerTest.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Linq;
-using System.Collections;
 using System.Collections.Generic;
 using Xunit;
-using Recurly;
-using Recurly.Resources;
 using Newtonsoft.Json;
 using RestSharp;
 using Moq;
@@ -22,7 +19,8 @@ namespace Recurly.Tests
         [Fact]
         public void EmptyEnumerableTest()
         {
-            var pager = Pager<MyResource>.Build("/next", new Dictionary<string, object> { }, GetEmptyPagerClient());
+            var client = MockClient.Build(PagerEmptyResponse());
+            var pager = Pager<MyResource>.Build("/resources", new Dictionary<string, object> { }, client);
 
             var i = 0;
             foreach (MyResource r in pager)
@@ -37,7 +35,8 @@ namespace Recurly.Tests
         [Fact]
         public void EnumerableTest()
         {
-            var pager = Pager<MyResource>.Build("/next", new Dictionary<string, object> { }, GetPagerSuccessClient());
+            var client = GetPagerSuccessClient();
+            var pager = Pager<MyResource>.Build("/resources", new Dictionary<string, object> { }, client);
 
             var i = 0;
             foreach (MyResource r in pager)
@@ -70,7 +69,8 @@ namespace Recurly.Tests
         [Fact]
         public void EnumerablePagesTest()
         {
-            var pager = Pager<MyResource>.Build("/next", new Dictionary<string, object> { }, GetPagerSuccessClient());
+            var client = GetPagerSuccessClient();
+            var pager = Pager<MyResource>.Build("/resources", new Dictionary<string, object> { }, client);
 
             var total = 0;
             var page = 0;
@@ -106,13 +106,17 @@ namespace Recurly.Tests
         [Fact]
         public void PagerFirstTest()
         {
+            var paramsMatcher = MockClient.ParameterMatcher(new Dictionary<string, object> {
+                { "limit", "1" },
+                { "a", "1" },
+            });
+            var client = MockClient.Build(paramsMatcher, PagerFirstResponse());
+
             var queryParams = new Dictionary<string, object> {
                 { "limit", "200" },
                 { "a", "1" },
             };
-            var clientMock = GetPagerFirstClient();
-
-            var pager = Pager<MyResource>.Build("/resources", queryParams, clientMock);
+            var pager = Pager<MyResource>.Build("/resources", queryParams, client);
 
             var resource = pager.First();
             Assert.Equal("First Resource", resource.MyString);
@@ -133,11 +137,14 @@ namespace Recurly.Tests
             Assert.Equal(42, count);
         }
 
-        private Recurly.Client GetPagerSuccessClient()
+        private Mock<IRestResponse<Pager<MyResource>>> PagerSuccessPage1Response()
         {
-            var page1 = new Pager<MyResource>()
+            // When there are no results, the server returns
+            // an empty array with HasMore == false
+            var page = new Pager<MyResource>()
             {
                 HasMore = true,
+                Next = "/next-page",
                 Data = new List<MyResource>()
                 {
                     new MyResource() { MyString = "A page 1 String" },
@@ -145,13 +152,19 @@ namespace Recurly.Tests
                     new MyResource() { MyString = "A page 1 String" },
                 }
             };
-            var page1Response = new Mock<IRestResponse<Pager<MyResource>>>();
-            page1Response.Setup(_ => _.StatusCode).Returns(System.Net.HttpStatusCode.OK);
-            page1Response.Setup(_ => _.Headers).Returns(new List<Parameter> { });
-            page1Response.Setup(_ => _.Data).Returns(page1);
+            var response = new Mock<IRestResponse<Pager<MyResource>>>();
+            response.Setup(_ => _.StatusCode).Returns(System.Net.HttpStatusCode.OK);
+            response.Setup(_ => _.Headers).Returns(new List<Parameter> { });
+            response.Setup(_ => _.Data).Returns(page);
 
-            var page2 = new Pager<MyResource>()
+            return response;
+        }
 
+        private Mock<IRestResponse<Pager<MyResource>>> PagerSuccessPage2Response()
+        {
+            // When there are no results, the server returns
+            // an empty array with HasMore == false
+            var page = new Pager<MyResource>()
             {
                 HasMore = false,
                 Data = new List<MyResource>()
@@ -160,24 +173,42 @@ namespace Recurly.Tests
                     new MyResource() { MyString = "A page 2 String" },
                 }
             };
-            var page2Response = new Mock<IRestResponse<Pager<MyResource>>>();
-            page2Response.Setup(_ => _.StatusCode).Returns(System.Net.HttpStatusCode.OK);
-            page2Response.Setup(_ => _.Headers).Returns(new List<Parameter> { });
-            page2Response.Setup(_ => _.Data).Returns(page2);
+            var response = new Mock<IRestResponse<Pager<MyResource>>>();
+            response.Setup(_ => _.StatusCode).Returns(System.Net.HttpStatusCode.OK);
+            response.Setup(_ => _.Headers).Returns(new List<Parameter> { });
+            response.Setup(_ => _.Data).Returns(page);
 
-            var mockIRestClient = new Mock<IRestClient>();
-            mockIRestClient
-                .SetupSequence(x => x.Execute<Pager<MyResource>>(It.IsAny<IRestRequest>()))
-                .Returns(page1Response.Object)
-                .Returns(page2Response.Object);
-
-            return new Recurly.Client("myapikey")
-            {
-                RestClient = mockIRestClient.Object
-            };
+            return response;
         }
 
-        private Recurly.Client GetEmptyPagerClient()
+        private MockClient GetPagerSuccessClient()
+        {
+            var page1Response = PagerSuccessPage1Response();
+            Func<IRestRequest, bool> page1Matcher = delegate (IRestRequest request)
+            {
+                if (request.Resource == "/resources")
+                {
+                    return true;
+                }
+                return false;
+            };
+            var page2Response = PagerSuccessPage2Response();
+            Func<IRestRequest, bool> page2Matcher = delegate (IRestRequest request)
+            {
+                if (request.Resource == "/next-page")
+                {
+                    return true;
+                }
+                return false;
+            };
+            var mockCollection = new Dictionary<Func<IRestRequest, bool>, Mock<IRestResponse<Pager<MyResource>>>> {
+                { page1Matcher, page1Response },
+                { page2Matcher, page2Response },
+            };
+            return MockClient.Build(mockCollection);
+        }
+
+        private Mock<IRestResponse<Pager<MyResource>>> PagerEmptyResponse()
         {
             // When there are no results, the server returns
             // an empty array with HasMore == false
@@ -186,23 +217,18 @@ namespace Recurly.Tests
                 HasMore = false,
                 Data = new List<MyResource>() { }
             };
-            var pageResponse = new Mock<IRestResponse<Pager<MyResource>>>();
-            pageResponse.Setup(_ => _.StatusCode).Returns(System.Net.HttpStatusCode.OK);
-            pageResponse.Setup(_ => _.Headers).Returns(new List<Parameter> { });
-            pageResponse.Setup(_ => _.Data).Returns(page);
-            var mockIRestClient = new Mock<IRestClient>();
-            mockIRestClient
-                .Setup(x => x.Execute<Pager<MyResource>>(It.IsAny<IRestRequest>()))
-                .Returns(pageResponse.Object);
+            var response = new Mock<IRestResponse<Pager<MyResource>>>();
+            response.Setup(_ => _.StatusCode).Returns(System.Net.HttpStatusCode.OK);
+            response.Setup(_ => _.Headers).Returns(new List<Parameter> { });
+            response.Setup(_ => _.Data).Returns(page);
 
-            return new Recurly.Client("myapikey")
-            {
-                RestClient = mockIRestClient.Object
-            };
+            return response;
         }
 
-        private Recurly.Client GetPagerFirstClient()
+        private Mock<IRestResponse<Pager<MyResource>>> PagerFirstResponse()
         {
+            // When there are no results, the server returns
+            // an empty array with HasMore == false
             var page = new Pager<MyResource>()
             {
                 HasMore = true,
@@ -211,44 +237,23 @@ namespace Recurly.Tests
                     new MyResource() { MyString = "First Resource" }
                 }
             };
-            var pageResponse = new Mock<IRestResponse<Pager<MyResource>>>();
-            pageResponse.Setup(_ => _.StatusCode).Returns(System.Net.HttpStatusCode.OK);
-            pageResponse.Setup(_ => _.Headers).Returns(new List<Parameter> { });
-            pageResponse.Setup(_ => _.Data).Returns(page);
+            var response = new Mock<IRestResponse<Pager<MyResource>>>();
+            response.Setup(_ => _.StatusCode).Returns(System.Net.HttpStatusCode.OK);
+            response.Setup(_ => _.Headers).Returns(new List<Parameter> { });
+            response.Setup(_ => _.Data).Returns(page);
 
-            var mockIRestClient = new Mock<IRestClient>();
-            var myParams = new List<Parameter> {
-                new RestSharp.Parameter("limit", "1", ParameterType.QueryString),
-                new RestSharp.Parameter("a", "1", ParameterType.QueryString),
-            };
+            return response;
+        }
 
-            // TODO: Find a better way to handle this specifically and the concept at a whole
-            Func<List<Parameter>, List<Parameter>, bool> sameParams = delegate (List<Parameter> a, List<Parameter> b)
-            {
-                var sortedA = a.OrderBy(x => x.Name).ToList();
-                var sortedB = b.OrderBy(x => x.Name).ToList();
-                int index = 0;
-                foreach (Parameter p in sortedA)
-                {
-                    var pB = sortedB.ElementAt(index);
-                    if (p.Name != pB.Name || String.Compare(p.Value.ToString(), pB.Value.ToString()) != 0)
-                    {
-                        return false;
-                    }
-                    index++;
-                }
-                return true;
-            };
+        private Mock<IRestResponse> PagerCountResponse()
+        {
+            var response = new Mock<IRestResponse>();
+            response.Setup(_ => _.StatusCode).Returns(System.Net.HttpStatusCode.OK);
+            response.Setup(_ => _.Headers).Returns(new List<Parameter> {
+                new RestSharp.Parameter("Recurly-Total-Records", "42", ParameterType.HttpHeader),
+            });
 
-
-            mockIRestClient
-                .Setup(x => x.Execute<Pager<MyResource>>(It.Is<RestRequest>(r => sameParams(r.Parameters, myParams) && r.Resource == "/resources")))
-                .Returns(pageResponse.Object);
-
-            return new Recurly.Client("myapikey")
-            {
-                RestClient = mockIRestClient.Object
-            };
+            return response;
         }
 
         private Recurly.Client GetPagerCountClient()

--- a/Recurly.Tests/PagerTest.cs
+++ b/Recurly.Tests/PagerTest.cs
@@ -1,10 +1,10 @@
 using System;
-using System.Linq;
 using System.Collections.Generic;
-using Xunit;
+using System.Linq;
+using Moq;
 using Newtonsoft.Json;
 using RestSharp;
-using Moq;
+using Xunit;
 
 namespace Recurly.Tests
 {

--- a/Recurly.Tests/UtilsTest.cs
+++ b/Recurly.Tests/UtilsTest.cs
@@ -1,8 +1,8 @@
-using Xunit;
-using Recurly;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
+using Recurly;
+using Xunit;
 
 namespace Recurly.Tests
 {

--- a/Recurly/BaseClient.cs
+++ b/Recurly/BaseClient.cs
@@ -1,14 +1,14 @@
 using System;
-using System.Net;
-using System.Threading.Tasks;
-using System.Runtime.CompilerServices;
-using System.Diagnostics;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
+using System.Diagnostics;
 using System.Linq;
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 using RestSharp;
 using RestSharp.Authenticators;
-using System.Threading;
 
 [assembly: InternalsVisibleTo("Recurly.Tests")]
 

--- a/Recurly/Client.cs
+++ b/Recurly/Client.cs
@@ -7,9 +7,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Diagnostics.CodeAnalysis;
 using Recurly.Resources;
 using RestSharp;
 

--- a/Recurly/Errors/ApiErrors.cs
+++ b/Recurly/Errors/ApiErrors.cs
@@ -5,8 +5,8 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
-using System.Runtime.Serialization;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
 
 namespace Recurly.Errors
 {

--- a/Recurly/FileSerializer.cs
+++ b/Recurly/FileSerializer.cs
@@ -1,6 +1,6 @@
 using System;
-using RestSharp.Deserializers;
 using RestSharp;
+using RestSharp.Deserializers;
 
 namespace Recurly
 {

--- a/Recurly/JsonSerializer.cs
+++ b/Recurly/JsonSerializer.cs
@@ -1,9 +1,9 @@
+using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
-using RestSharp.Serializers;
-using RestSharp.Deserializers;
 using RestSharp;
-using System.IO;
+using RestSharp.Deserializers;
+using RestSharp.Serializers;
 
 namespace Recurly
 {

--- a/Recurly/Pager.cs
+++ b/Recurly/Pager.cs
@@ -21,7 +21,7 @@ namespace Recurly
         [JsonProperty("next")]
         public string Next { get; set; }
 
-        internal Recurly.Client RecurlyClient { get; set; }
+        internal Recurly.BaseClient RecurlyClient { get; set; }
 
         internal Dictionary<string, object> QueryParams { get; set; }
 
@@ -31,7 +31,7 @@ namespace Recurly
 
         public Pager() { }
 
-        internal static Pager<T> Build(string url, Dictionary<string, object> queryParams, Client client)
+        internal static Pager<T> Build(string url, Dictionary<string, object> queryParams, BaseClient client)
         {
             return new Pager<T>()
             {

--- a/Recurly/Pager.cs
+++ b/Recurly/Pager.cs
@@ -1,11 +1,11 @@
 using System;
-using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
-using RestSharp;
-using Newtonsoft.Json;
-using System.Threading.Tasks;
+using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using RestSharp;
 
 namespace Recurly
 {

--- a/Recurly/Utils.cs
+++ b/Recurly/Utils.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Globalization;
+using System.Text;
 
 namespace Recurly
 {


### PR DESCRIPTION
Refactoring tests to use a standard `MockClient` that has enhanced capabilities for mocking `RestSharp` components.