### PR TITLE
Add timeframe query params to cancel subscription endpoint

### DIFF
--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -439,13 +439,14 @@ namespace Recurly
         /// </summary>
         public void Cancel(string timeframe = null)
         {
+          var url = UrlPrefix + Uri.EscapeDataString(Uuid) + "/cancel";
           if (timeframe == null) {
             Client.Instance.PerformRequest(Client.HttpRequestMethod.Put,
-                UrlPrefix + Uri.EscapeDataString(Uuid) + "/cancel",
+                url,
                 ReadXml);
           } else {
             Client.Instance.PerformRequest(Client.HttpRequestMethod.Put,
-                UrlPrefix + Uri.EscapeDataString(Uuid) + "/cancel?timeframe=" + timeframe,
+                url += "?timeframe=" + timeframe,
                 ReadXml);
           }
         }

--- a/Library/Subscription.cs
+++ b/Library/Subscription.cs
@@ -437,11 +437,17 @@ namespace Recurly
         /// Cancel an active subscription.  The subscription will not renew, but will continue to be active
         /// through the remainder of the current term.
         /// </summary>
-        public void Cancel()
+        public void Cancel(string timeframe = null)
         {
+          if (timeframe == null) {
             Client.Instance.PerformRequest(Client.HttpRequestMethod.Put,
                 UrlPrefix + Uri.EscapeDataString(Uuid) + "/cancel",
                 ReadXml);
+          } else {
+            Client.Instance.PerformRequest(Client.HttpRequestMethod.Put,
+                UrlPrefix + Uri.EscapeDataString(Uuid) + "/cancel?timeframe=" + timeframe,
+                ReadXml);
+          }
         }
 
         /// <summary>

--- a/Test/SubscriptionTest.cs
+++ b/Test/SubscriptionTest.cs
@@ -281,6 +281,29 @@ namespace Recurly.Test
         }
 
         [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void CancelSubscriptionTimeframe()
+        {
+            var plan = new Plan(GetMockPlanCode(), GetMockPlanName())
+            {
+                Description = "Cancel Subscription Test with Timeframe"
+            };
+            plan.UnitAmountInCents.Add("USD", 100);
+            plan.Create();
+            PlansToDeactivateOnDispose.Add(plan);
+
+            var account = CreateNewAccountWithBillingInfo();
+
+            var sub = new Subscription(account, plan, "USD");
+            sub.TotalBillingCycles = 2;
+            sub.Create();
+
+            sub.Cancel("bill_date");
+
+            Assert.Equal(sub.ExpiresAt, sub.CurrentPeriodEndsAt);
+            sub.ExpiresAt.Should().NotBe(sub.CurrentTermEndsAt);
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Integration)]
         public void ReactivateSubscription()
         {
             var plan = new Plan(GetMockPlanCode(), GetMockPlanName())


### PR DESCRIPTION
Adds the timeframe query params for the [cancel subscription endpoint](https://dev.recurly.com/docs/cancel-subscription). 