### PR TITLE
Support items on subscriptions

### DIFF
--- a/Library/Configuration/Settings.cs
+++ b/Library/Configuration/Settings.cs
@@ -78,7 +78,7 @@ namespace Recurly.Configuration
         }
 
         protected const string RecurlyServerUri = "https://{0}.recurly.com/v2{1}";
-        public const string RecurlyApiVersion = "2.26";
+        public const string RecurlyApiVersion = "2.27";
         public const string ValidDomain = ".recurly.com";
 
         // static, unlikely to change

--- a/Library/List/SubscriptionAddOnList.cs
+++ b/Library/List/SubscriptionAddOnList.cs
@@ -164,5 +164,20 @@ namespace Recurly
             var sub = new SubscriptionAddOn(planAddOnCode, addOnType, unitAmountInCents, quantity);
             base.Add(sub);
         }
+
+        // Supports item code as add-on code. Also supports plan add-on code as add-on code.
+        public void Add(string addOnCode, string addOnSource, int unitAmountInCents, int quantity = 1)
+        {
+          var sub = new SubscriptionAddOn(addOnCode, addOnSource, unitAmountInCents, quantity);
+          base.Add(sub);
+        }
+
+        public void Add(string planAddOnCode, string addOnSource, int quantity = 1)
+        {
+          var unitAmount = _subscription.Plan.AddOns.Find(ao => ao.AddOnCode == planAddOnCode).UnitAmountInCents[_subscription.Currency];
+          var sub = new SubscriptionAddOn(planAddOnCode, addOnSource, unitAmount, quantity);
+          base.Add(sub);
+        }
+
     }
 }

--- a/Library/Plan.cs
+++ b/Library/Plan.cs
@@ -27,6 +27,7 @@ namespace Recurly
         public bool? DisplayQuantity { get; set; }
         public bool? DisplayPhoneNumber { get; set; }
         public bool? BypassHostedConfirmation { get; set; }
+        public bool? AllowAnyItemOnSubscriptions { get; set; }
 
         public string UnitName { get; set; }
         public string PaymentPageTOSLink { get; set; }
@@ -285,6 +286,10 @@ namespace Recurly
                         BypassHostedConfirmation = reader.ReadElementContentAsBoolean();
                         break;
 
+                    case "allow_any_item_on_subscriptions":
+                        AllowAnyItemOnSubscriptions = reader.ReadElementContentAsBoolean();
+                        break;
+
                     case "unit_name":
                         UnitName = reader.ReadElementContentAsString();
                         break;
@@ -413,6 +418,9 @@ namespace Recurly
             if (BypassHostedConfirmation.HasValue)
                 xmlWriter.WriteElementString("bypass_hosted_confirmation", BypassHostedConfirmation.Value.AsString());
 
+            if (AllowAnyItemOnSubscriptions.HasValue)
+                xmlWriter.WriteElementString("allow_any_item_on_subscriptions", AllowAnyItemOnSubscriptions.Value.AsString());
+                
             if (TaxExempt.HasValue)
                 xmlWriter.WriteElementString("tax_exempt", TaxExempt.Value.AsString());
 

--- a/Library/SubscriptionAddOn.cs
+++ b/Library/SubscriptionAddOn.cs
@@ -13,6 +13,7 @@ namespace Recurly
         public Adjustment.RevenueSchedule? RevenueScheduleType { get; set; }
         public float? UsagePercentage { get; set; }
         public string TierType { get; set; }
+        public string AddOnSource { get; set; }
 
         public SubscriptionAddOn(XmlTextReader reader)
         {
@@ -42,6 +43,15 @@ namespace Recurly
             AddOnCode = addOnCode;
             TierType = tierType;
             Quantity = quantity;
+        }
+
+        // new constructor including add-on source
+        public SubscriptionAddOn(string addOnCode, string addOnSource, int unitAmountInCents, int quantity = 1)
+        {
+          AddOnCode = addOnCode;
+          AddOnSource = addOnSource;
+          UnitAmountInCents = unitAmountInCents;
+          Quantity = quantity;
         }
 
         internal override void ReadXml(XmlTextReader reader)
@@ -90,6 +100,10 @@ namespace Recurly
                         TierType = reader.ReadElementContentAsString();
                         break;
 
+                    case "add_on_source":
+                        AddOnSource = reader.ReadElementContentAsString();
+                        break;
+
                 }
             }
         }
@@ -112,6 +126,9 @@ namespace Recurly
 
             if (TierType != null)
                 writer.WriteElementString("tier_type", TierType);
+
+            if (AddOnSource != null)
+                writer.WriteElementString("add_on_source", AddOnSource);
 
             writer.WriteEndElement();
         }

--- a/Test/List/SubscriptionAddOnListTest.cs
+++ b/Test/List/SubscriptionAddOnListTest.cs
@@ -72,5 +72,29 @@ namespace Recurly.Test.List
                 .Match<SubscriptionAddOn>(x => x.AddOnCode == addOnCode)
                 .And.Match<SubscriptionAddOn>(x => x.UnitAmountInCents == addOn.UnitAmountInCents[sub.Currency]);
         }
+
+        [Fact]
+        public void AddItemAddOn()
+        {
+            var item = new Item(GetMockItemCode(), GetMockItemName()) {Description = "Mock Item"};
+            item.Description = "A test description";
+            item.Create();
+
+            var account = new Account("1");
+
+            var plan = new Plan(GetMockPlanCode(), GetMockPlanName());
+            plan.UnitAmountInCents.Add(USD, 100);
+            plan.Create();
+
+            var sub = new Subscription(account, plan, USD);
+
+            sub.AddOns.Add(item.ItemCode, "item", 199, 1);
+
+            var newItemAddOn = sub.AddOns.First();
+            newItemAddOn.Should()
+                .Match<SubscriptionAddOn>(x => x.AddOnCode == item.ItemCode)
+                .And.Match<SubscriptionAddOn>(x => x.UnitAmountInCents == 199)
+                .And.Match<SubscriptionAddOn>(x => x.AddOnSource == "item");
+        }
     }
 }


### PR DESCRIPTION
This PR adds support for items on subscriptions, where merchants may now associate a subscription add-on with an item in their catalog.

`allow_any_item_on_subscriptions` has been added to the `Plan` class. It is used to determine whether items can be assigned as add-ons to individual subscriptions. If `true`, items can be assigned as add-ons to individual subscription add-ons. If `false`, only plan add-ons can be used.

`add_on_source`, added to the `SubscriptionAddOn` class, is used to determine where the associated add-on data is pulled from. If this value is set to `plan_add_on` or left blank, then add-on data will be pulled from the plan's add-ons. If the associated  `plan` has `allow_any_item_on_subscriptions` set to `true` and this field is set to `item`, then the associated add-on data will be pulled from the site's item catalog.

Code example:
```c#
var subscription = new Subscription(account, plan, "USD"); // account, plan, currency

// create sub add-on from item
subscription.AddOns.Add(item.ItemCode, "item", 299, 1); // add_on_code or item_code, add_on_source, unit_amount_in_cents, quantity

// create sub add-on from existing add-on
subscription.AddOns.Add(addon1.AddOnCode); 
// or
subscription.AddOns.Add(addon1.AddOnCode, "plan_add_on"); // add_on_code, add_on_source

subscription.Create();
```