### PR TITLE
Release 1.17.5

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,14 @@
 Unreleased
 ===============
 
+1.17.5 (stable) / 2020-06-30
+- Update serializer for item-backed add-ons to accommodate QBP [PR](https://github.com/recurly/recurly-client-dotnet/pull/515)
+- Add timeframe query params to cancel subscription endpoint [PR](https://github.com/recurly/recurly-client-dotnet/pull/525)
+- BACS support [PR](https://github.com/recurly/recurly-client-dotnet/pull/528)
+- Repair test to expect a validation exception [PR](https://github.com/recurly/recurly-client-dotnet/pull/529)
+- Expect validation exception when converting trial with fake token [PR](https://github.com/recurly/recurly-client-dotnet/pull/530)
+- Support items on subscriptions [PR](https://github.com/recurly/recurly-client-dotnet/pull/539)
+
 1.17.4 (stable) / 2020-04-15
 ===============
 

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.17.4.0")]
-[assembly: AssemblyFileVersion("1.17.4.0")]
+[assembly: AssemblyVersion("1.17.5.0")]
+[assembly: AssemblyFileVersion("1.17.5.0")]

--- a/dist/recurly.nuspec
+++ b/dist/recurly.nuspec
@@ -2,14 +2,14 @@
 <package >
   <metadata>
     <id>recurly-api-client</id>
-    <version>1.17.4</version>
+    <version>1.17.5</version>
     <authors>recurly</authors>
     <owners>recurly</owners>
     <licenseUrl>https://github.com/recurly/recurly-client-net/blob/master/LICENSE.txt</licenseUrl>
     <projectUrl>https://github.com/recurly/recurly-client-net</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>An API Client for Recurly - Subscription billing automation.</description>
-    <copyright>Copyright 2019</copyright>
+    <copyright>Copyright 2020</copyright>
     <tags>billing api client subscription recurly</tags>
   </metadata>
 </package>


### PR DESCRIPTION
This brings us up to API version 2.27. There are no breaking changes.

- Update serializer for item-backed add-ons to accommodate QBP https://github.com/recurly/recurly-client-dotnet/pull/515
- Add timeframe query params to cancel subscription endpoint https://github.com/recurly/recurly-client-dotnet/pull/525
- BACS support https://github.com/recurly/recurly-client-dotnet/pull/528
- Repair test to expect a validation exception https://github.com/recurly/recurly-client-dotnet/pull/529
- Expect validation exception when converting trial with fake token https://github.com/recurly/recurly-client-dotnet/pull/530
- Support items on subscriptions https://github.com/recurly/recurly-client-dotnet/pull/539