### PR TITLE
Adding Response class to Resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,20 @@ catch (Recurly.Errors.NetworkError ex)
 }
 ```
 
+### HTTP Metadata
+
+Sometimes you might want to get some additional information about the underlying HTTP request and response. Instead of returning this information directly and forcing the programmer to unwrap it, we inject this metadata into the top level resource that was returned. You can access the response by calling `GetResponse()` on any Resource.
+
+```csharp
+Account account = client.GetAccount(accountId);
+Response response = account.GetResponse();
+response.RawResponse // String body of the API response
+response.StatusCode // HTTP status code of the API response
+response.RequestId // "5b7019241a21d314-ATL"
+response.Headers // IList<Parameter> of all API response headers
+```
+
+
 ### Webhooks
 
 Recurly can send webhooks to any publicly accessible server.

--- a/README.md
+++ b/README.md
@@ -278,6 +278,12 @@ response.RequestId // "5b7019241a21d314-ATL"
 response.Headers // IList<Parameter> of all API response headers
 ```
 
+Rate Limit information is also accessible on the `Response` class. These values will be `null` when the corresponding headers are absent from the response. More information can be found on the developer portal's [Rate Limits](https://developers.recurly.com/api/v2019-10-10/index.html#section/Getting-Started/Limits) section.
+```csharp
+response.RateLimit // 2000  
+response.RateLimitRemaining // 1990
+response.RateLimitReset // 1595965380
+```
 
 ### Webhooks
 

--- a/Recurly.Tests/BaseClientTest.cs
+++ b/Recurly.Tests/BaseClientTest.cs
@@ -45,9 +45,9 @@ namespace Recurly.Tests
         {
             var client = MockClient.Build(SuccessResponse(System.Net.HttpStatusCode.OK));
             MyResource resource = client.GetResource("benjamin", "param1", new DateTime(2020, 01, 01));
-            Assert.Equal(System.Net.HttpStatusCode.OK, resource.Response.StatusCode);
-            Assert.Empty(resource.Response.Headers);
-            Assert.Equal("{\"my_string\": \"benjamin\"}", resource.Response.RawResponse);
+            Assert.Equal(System.Net.HttpStatusCode.OK, resource.GetResponse().StatusCode);
+            Assert.Empty(resource.GetResponse().Headers);
+            Assert.Equal("{\"my_string\": \"benjamin\"}", resource.GetResponse().RawResponse);
         }
 
         [Fact]

--- a/Recurly.Tests/BaseClientTest.cs
+++ b/Recurly.Tests/BaseClientTest.cs
@@ -41,6 +41,16 @@ namespace Recurly.Tests
         }
 
         [Fact]
+        public void WillPopulateResponseOnResource()
+        {
+            var client = MockClient.Build(SuccessResponse(System.Net.HttpStatusCode.OK));
+            MyResource resource = client.GetResource("benjamin", "param1", new DateTime(2020, 01, 01));
+            Assert.Equal(System.Net.HttpStatusCode.OK, resource.Response.StatusCode);
+            Assert.Empty(resource.Response.Headers);
+            Assert.Equal("{\"my_string\": \"benjamin\"}", resource.Response.RawResponse);
+        }
+
+        [Fact]
         public void CanProperlyCreateAResource()
         {
             var client = MockClient.Build(SuccessResponse(System.Net.HttpStatusCode.Created));

--- a/Recurly.Tests/MockClient.cs
+++ b/Recurly.Tests/MockClient.cs
@@ -45,7 +45,7 @@ namespace Recurly.Tests
                     .Returns(item.Value.Object);
 
                 mockIRestClient
-                    .Setup(x => x.ExecuteTaskAsync<T>(It.Is<IRestRequest>(r => item.Key(r)), It.IsAny<CancellationToken>()))
+                    .Setup(x => x.ExecuteAsync<T>(It.Is<IRestRequest>(r => item.Key(r)), It.IsAny<CancellationToken>()))
                     .Returns(Task.FromResult(item.Value.Object));
             }
 

--- a/Recurly.Tests/ResponseTest.cs
+++ b/Recurly.Tests/ResponseTest.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using Moq;
+using Recurly;
+using RestSharp;
+using Xunit;
+
+namespace Recurly.Tests
+{
+    public class ResponseTest
+    {
+        private IList<Parameter> TestHeaders = new List<Parameter>()
+        {
+            new Parameter("Content-Type", "application/value", ParameterType.HttpHeader),
+            new Parameter("X-Request-Id", "the-request-id", ParameterType.HttpHeader),
+            new Parameter("X-RateLimit-Limit", "4000", ParameterType.HttpHeader),
+            new Parameter("X-RateLimit-Remaining", "42", ParameterType.HttpHeader),
+            new Parameter("X-RateLimit-Reset", "1595451960", ParameterType.HttpHeader),
+            new Parameter("Recurly-Total-Records", "42", ParameterType.HttpHeader),
+        };
+
+        public ResponseTest() { }
+
+        [Fact]
+        public void CanGetStatusCode()
+        {
+            var response = BuildResponse();
+            Assert.Equal(System.Net.HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public void CanGetRawResponse()
+        {
+            var response = BuildResponse();
+            Assert.Equal("raw-response", response.RawResponse);
+        }
+
+        [Fact]
+        public void CanGetRequestId()
+        {
+            var response = BuildResponse();
+            Assert.Equal("the-request-id", response.RequestId);
+        }
+
+        [Fact]
+        public void CanGetRateLimit()
+        {
+            var response = BuildResponse();
+            Assert.Equal(4000, response.RateLimit);
+        }
+
+        [Fact]
+        public void CanGetRateLimitRemaining()
+        {
+            var response = BuildResponse();
+            Assert.Equal(42, response.RateLimitRemaining);
+        }
+
+        [Fact]
+        public void CanGetRateLimitReset()
+        {
+            var response = BuildResponse();
+            Assert.Equal(1595451960, response.RateLimitReset);
+        }
+
+        [Fact]
+        public void CanGetRecordCount()
+        {
+            var response = BuildResponse();
+            Assert.Equal(42, response.RecordCount);
+        }
+
+        [Fact]
+        public void CanGetRecordCountUnset()
+        {
+            var response = new Response()
+            {
+                Headers = new List<Parameter>()
+            };
+            Assert.Null(response.RecordCount);
+        }
+
+        [Fact]
+        public void CanGetRecordCountInvalid()
+        {
+            var response = new Response()
+            {
+                Headers = new List<Parameter>()
+                {
+                    new Parameter("Recurly-Total-Records", "banana", ParameterType.HttpHeader),
+                }
+            };
+            Assert.Null(response.RecordCount);
+        }
+
+        [Fact]
+        public void CanGetContentType()
+        {
+            var response = BuildResponse();
+            Assert.Equal("application/value", response.ContentType);
+        }
+
+        private Response BuildResponse()
+        {
+            var response = new Response()
+            {
+                StatusCode = System.Net.HttpStatusCode.OK,
+                RawResponse = "raw-response",
+                Headers = TestHeaders
+            };
+            return response;
+        }
+    }
+}

--- a/Recurly.Tests/ResponseTest.cs
+++ b/Recurly.Tests/ResponseTest.cs
@@ -9,14 +9,14 @@ namespace Recurly.Tests
 {
     public class ResponseTest
     {
-        private IList<Parameter> TestHeaders = new List<Parameter>()
+        private IList<Header> TestHeaders = new List<Header>()
         {
-            new Parameter("Content-Type", "application/value", ParameterType.HttpHeader),
-            new Parameter("X-Request-Id", "the-request-id", ParameterType.HttpHeader),
-            new Parameter("X-RateLimit-Limit", "4000", ParameterType.HttpHeader),
-            new Parameter("X-RateLimit-Remaining", "42", ParameterType.HttpHeader),
-            new Parameter("X-RateLimit-Reset", "1595451960", ParameterType.HttpHeader),
-            new Parameter("Recurly-Total-Records", "42", ParameterType.HttpHeader),
+            new Header("Content-Type", "application/value"),
+            new Header("X-Request-Id", "the-request-id"),
+            new Header("X-RateLimit-Limit", "4000"),
+            new Header("X-RateLimit-Remaining", "42"),
+            new Header("X-RateLimit-Reset", "1595451960"),
+            new Header("Recurly-Total-Records", "42"),
         };
 
         public ResponseTest() { }
@@ -75,7 +75,7 @@ namespace Recurly.Tests
         {
             var response = new Response()
             {
-                Headers = new List<Parameter>()
+                Headers = new List<Header>()
             };
             Assert.Null(response.RecordCount);
         }
@@ -85,9 +85,9 @@ namespace Recurly.Tests
         {
             var response = new Response()
             {
-                Headers = new List<Parameter>()
+                Headers = new List<Header>()
                 {
-                    new Parameter("Recurly-Total-Records", "banana", ParameterType.HttpHeader),
+                    new Header("Recurly-Total-Records", "banana"),
                 }
             };
             Assert.Null(response.RecordCount);

--- a/Recurly/BaseClient.cs
+++ b/Recurly/BaseClient.cs
@@ -58,7 +58,7 @@ namespace Recurly
             {
                 var resp = t.Result;
                 this.HandleResponse(resp);
-                if (resp.Data is object)
+                if (resp.Data is Resource)
                     resp.Data.Response = Response.Build(resp);
                 return resp.Data;
             });
@@ -70,7 +70,7 @@ namespace Recurly
             var request = BuildRequest(method, url, body, queryParams, options);
             var resp = RestClient.Execute<T>(request);
             this.HandleResponse(resp);
-            if (resp.Data is object)
+            if (resp.Data is Resource)
                 resp.Data.Response = Response.Build(resp);
             return resp.Data;
         }

--- a/Recurly/BaseClient.cs
+++ b/Recurly/BaseClient.cs
@@ -59,7 +59,7 @@ namespace Recurly
                 var resp = t.Result;
                 this.HandleResponse(resp);
                 if (resp.Data is Resource)
-                    resp.Data.Response = Response.Build(resp);
+                    resp.Data.SetResponse(Response.Build(resp));
                 return resp.Data;
             });
         }
@@ -71,7 +71,7 @@ namespace Recurly
             var resp = RestClient.Execute<T>(request);
             this.HandleResponse(resp);
             if (resp.Data is Resource)
-                resp.Data.Response = Response.Build(resp);
+                resp.Data.SetResponse(Response.Build(resp));
             return resp.Data;
         }
 

--- a/Recurly/Client.cs
+++ b/Recurly/Client.cs
@@ -57,7 +57,7 @@ namespace Recurly
         {
             var urlParams = new Dictionary<string, object> { { "site_id", siteId } };
             var url = this.InterpolatePath("/sites/{site_id}", urlParams);
-            return MakeRequest<Site>(Method.GET, url, null, null, options);
+            return MakeRequestA<Site>(Method.GET, url, null, null, options);
         }
 
 

--- a/Recurly/Client.cs
+++ b/Recurly/Client.cs
@@ -57,7 +57,7 @@ namespace Recurly
         {
             var urlParams = new Dictionary<string, object> { { "site_id", siteId } };
             var url = this.InterpolatePath("/sites/{site_id}", urlParams);
-            return MakeRequestA<Site>(Method.GET, url, null, null, options);
+            return MakeRequest<Site>(Method.GET, url, null, null, options);
         }
 
 
@@ -326,7 +326,7 @@ namespace Recurly
         {
             var urlParams = new Dictionary<string, object> { { "account_id", accountId } };
             var url = this.InterpolatePath("/accounts/{account_id}/acquisition", urlParams);
-            MakeRequest<object>(Method.DELETE, url, null, null, options);
+            MakeRequest<EmptyResource>(Method.DELETE, url, null, null, options);
         }
 
 
@@ -339,11 +339,11 @@ namespace Recurly
         /// Acquisition data was succesfully deleted.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        public Task<object> RemoveAccountAcquisitionAsync(string accountId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)
+        public Task<EmptyResource> RemoveAccountAcquisitionAsync(string accountId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "account_id", accountId } };
             var url = this.InterpolatePath("/accounts/{account_id}/acquisition", urlParams);
-            return MakeRequestAsync<object>(Method.DELETE, url, null, null, options, cancellationToken);
+            return MakeRequestAsync<EmptyResource>(Method.DELETE, url, null, null, options, cancellationToken);
         }
 
 
@@ -498,7 +498,7 @@ namespace Recurly
         {
             var urlParams = new Dictionary<string, object> { { "account_id", accountId } };
             var url = this.InterpolatePath("/accounts/{account_id}/billing_info", urlParams);
-            MakeRequest<object>(Method.DELETE, url, null, null, options);
+            MakeRequest<EmptyResource>(Method.DELETE, url, null, null, options);
         }
 
 
@@ -511,11 +511,11 @@ namespace Recurly
         /// Billing information deleted
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        public Task<object> RemoveBillingInfoAsync(string accountId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)
+        public Task<EmptyResource> RemoveBillingInfoAsync(string accountId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "account_id", accountId } };
             var url = this.InterpolatePath("/accounts/{account_id}/billing_info", urlParams);
-            return MakeRequestAsync<object>(Method.DELETE, url, null, null, options, cancellationToken);
+            return MakeRequestAsync<EmptyResource>(Method.DELETE, url, null, null, options, cancellationToken);
         }
 
 
@@ -1037,7 +1037,7 @@ namespace Recurly
         {
             var urlParams = new Dictionary<string, object> { { "account_id", accountId }, { "shipping_address_id", shippingAddressId } };
             var url = this.InterpolatePath("/accounts/{account_id}/shipping_addresses/{shipping_address_id}", urlParams);
-            MakeRequest<object>(Method.DELETE, url, null, null, options);
+            MakeRequest<EmptyResource>(Method.DELETE, url, null, null, options);
         }
 
 
@@ -1051,11 +1051,11 @@ namespace Recurly
         /// Shipping address deleted.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        public Task<object> RemoveShippingAddressAsync(string accountId, string shippingAddressId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)
+        public Task<EmptyResource> RemoveShippingAddressAsync(string accountId, string shippingAddressId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "account_id", accountId }, { "shipping_address_id", shippingAddressId } };
             var url = this.InterpolatePath("/accounts/{account_id}/shipping_addresses/{shipping_address_id}", urlParams);
-            return MakeRequestAsync<object>(Method.DELETE, url, null, null, options, cancellationToken);
+            return MakeRequestAsync<EmptyResource>(Method.DELETE, url, null, null, options, cancellationToken);
         }
 
 
@@ -2178,7 +2178,7 @@ namespace Recurly
         {
             var urlParams = new Dictionary<string, object> { { "line_item_id", lineItemId } };
             var url = this.InterpolatePath("/line_items/{line_item_id}", urlParams);
-            MakeRequest<object>(Method.DELETE, url, null, null, options);
+            MakeRequest<EmptyResource>(Method.DELETE, url, null, null, options);
         }
 
 
@@ -2191,11 +2191,11 @@ namespace Recurly
         /// Line item deleted.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        public Task<object> RemoveLineItemAsync(string lineItemId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)
+        public Task<EmptyResource> RemoveLineItemAsync(string lineItemId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "line_item_id", lineItemId } };
             var url = this.InterpolatePath("/line_items/{line_item_id}", urlParams);
-            return MakeRequestAsync<object>(Method.DELETE, url, null, null, options, cancellationToken);
+            return MakeRequestAsync<EmptyResource>(Method.DELETE, url, null, null, options, cancellationToken);
         }
 
 
@@ -3177,7 +3177,7 @@ namespace Recurly
         {
             var urlParams = new Dictionary<string, object> { { "subscription_id", subscriptionId } };
             var url = this.InterpolatePath("/subscriptions/{subscription_id}/change", urlParams);
-            MakeRequest<object>(Method.DELETE, url, null, null, options);
+            MakeRequest<EmptyResource>(Method.DELETE, url, null, null, options);
         }
 
 
@@ -3190,11 +3190,11 @@ namespace Recurly
         /// Subscription change was deleted.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        public Task<object> RemoveSubscriptionChangeAsync(string subscriptionId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)
+        public Task<EmptyResource> RemoveSubscriptionChangeAsync(string subscriptionId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "subscription_id", subscriptionId } };
             var url = this.InterpolatePath("/subscriptions/{subscription_id}/change", urlParams);
-            return MakeRequestAsync<object>(Method.DELETE, url, null, null, options, cancellationToken);
+            return MakeRequestAsync<EmptyResource>(Method.DELETE, url, null, null, options, cancellationToken);
         }
 
 

--- a/Recurly/EmptyResource.cs
+++ b/Recurly/EmptyResource.cs
@@ -3,9 +3,5 @@ using System.Diagnostics.CodeAnalysis;
 namespace Recurly
 {
     [ExcludeFromCodeCoverage]
-    public class Resource
-    {
-        public Response Response { get; set; }
-
-    }
+    public class EmptyResource : Resource { }
 }

--- a/Recurly/Errors/ApiErrors.cs
+++ b/Recurly/Errors/ApiErrors.cs
@@ -128,96 +128,112 @@ namespace Recurly.Errors
         public BadRequest(string message) : base(message) { }
         public BadRequest(string message, Exception inner) : base(message, inner) { }
     }
+    [ExcludeFromCodeCoverage]
     public class InternalServer : ApiError
     {
         public InternalServer() { }
         public InternalServer(string message) : base(message) { }
         public InternalServer(string message, Exception inner) : base(message, inner) { }
     }
+    [ExcludeFromCodeCoverage]
     public class ImmutableSubscription : ApiError
     {
         public ImmutableSubscription() { }
         public ImmutableSubscription(string message) : base(message) { }
         public ImmutableSubscription(string message, Exception inner) : base(message, inner) { }
     }
+    [ExcludeFromCodeCoverage]
     public class InvalidApiKey : ApiError
     {
         public InvalidApiKey() { }
         public InvalidApiKey(string message) : base(message) { }
         public InvalidApiKey(string message, Exception inner) : base(message, inner) { }
     }
+    [ExcludeFromCodeCoverage]
     public class InvalidApiVersion : ApiError
     {
         public InvalidApiVersion() { }
         public InvalidApiVersion(string message) : base(message) { }
         public InvalidApiVersion(string message, Exception inner) : base(message, inner) { }
     }
+    [ExcludeFromCodeCoverage]
     public class InvalidContentType : ApiError
     {
         public InvalidContentType() { }
         public InvalidContentType(string message) : base(message) { }
         public InvalidContentType(string message, Exception inner) : base(message, inner) { }
     }
+    [ExcludeFromCodeCoverage]
     public class InvalidPermissions : ApiError
     {
         public InvalidPermissions() { }
         public InvalidPermissions(string message) : base(message) { }
         public InvalidPermissions(string message, Exception inner) : base(message, inner) { }
     }
+    [ExcludeFromCodeCoverage]
     public class InvalidToken : ApiError
     {
         public InvalidToken() { }
         public InvalidToken(string message) : base(message) { }
         public InvalidToken(string message, Exception inner) : base(message, inner) { }
     }
+    [ExcludeFromCodeCoverage]
     public class NotFound : ApiError
     {
         public NotFound() { }
         public NotFound(string message) : base(message) { }
         public NotFound(string message, Exception inner) : base(message, inner) { }
     }
+    [ExcludeFromCodeCoverage]
     public class SimultaneousRequest : ApiError
     {
         public SimultaneousRequest() { }
         public SimultaneousRequest(string message) : base(message) { }
         public SimultaneousRequest(string message, Exception inner) : base(message, inner) { }
     }
+    [ExcludeFromCodeCoverage]
     public class Transaction : ApiError
     {
         public Transaction() { }
         public Transaction(string message) : base(message) { }
         public Transaction(string message, Exception inner) : base(message, inner) { }
     }
+    [ExcludeFromCodeCoverage]
     public class Unauthorized : ApiError
     {
         public Unauthorized() { }
         public Unauthorized(string message) : base(message) { }
         public Unauthorized(string message, Exception inner) : base(message, inner) { }
     }
+    [ExcludeFromCodeCoverage]
     public class UnavailableInApiVersion : ApiError
     {
         public UnavailableInApiVersion() { }
         public UnavailableInApiVersion(string message) : base(message) { }
         public UnavailableInApiVersion(string message, Exception inner) : base(message, inner) { }
     }
+    [ExcludeFromCodeCoverage]
     public class UnknownApiVersion : ApiError
     {
         public UnknownApiVersion() { }
         public UnknownApiVersion(string message) : base(message) { }
         public UnknownApiVersion(string message, Exception inner) : base(message, inner) { }
     }
+    [ExcludeFromCodeCoverage]
     public class Validation : ApiError
     {
         public Validation() { }
         public Validation(string message) : base(message) { }
         public Validation(string message, Exception inner) : base(message, inner) { }
     }
+    [ExcludeFromCodeCoverage]
     public class MissingFeature : ApiError
     {
         public MissingFeature() { }
         public MissingFeature(string message) : base(message) { }
         public MissingFeature(string message, Exception inner) : base(message, inner) { }
     }
+    [ExcludeFromCodeCoverage]
     public class RateLimited : ApiError
     {
         public RateLimited() { }

--- a/Recurly/Pager.cs
+++ b/Recurly/Pager.cs
@@ -90,7 +90,7 @@ namespace Recurly
             this.Url = pager.Url;
             this.QueryParams = pager.QueryParams;
             this.Options = pager.Options;
-            this.Response = pager.Response;
+            this.SetResponse(pager.GetResponse());
             this._pristine = false;
         }
 

--- a/Recurly/Pager.cs
+++ b/Recurly/Pager.cs
@@ -10,7 +10,7 @@ using RestSharp;
 namespace Recurly
 {
     [JsonObject]
-    public class Pager<T> : IEnumerator<T>, IEnumerable<T>
+    public class Pager<T> : Resource, IEnumerator<T>, IEnumerable<T>
     {
         [JsonProperty("has_more")]
         public bool HasMore { get; set; }
@@ -90,6 +90,7 @@ namespace Recurly
             this.Url = pager.Url;
             this.QueryParams = pager.QueryParams;
             this.Options = pager.Options;
+            this.Response = pager.Response;
             this._pristine = false;
         }
 

--- a/Recurly/Resource.cs
+++ b/Recurly/Resource.cs
@@ -5,7 +5,17 @@ namespace Recurly
     [ExcludeFromCodeCoverage]
     public class Resource
     {
-        public Response Response { get; set; }
+        private Response _response;
+
+        public Response GetResponse()
+        {
+            return _response;
+        }
+
+        public void SetResponse(Response response)
+        {
+            _response = response;
+        }
 
     }
 }

--- a/Recurly/Resource.cs
+++ b/Recurly/Resource.cs
@@ -12,7 +12,7 @@ namespace Recurly
             return _response;
         }
 
-        public void SetResponse(Response response)
+        internal void SetResponse(Response response)
         {
             _response = response;
         }

--- a/Recurly/Response.cs
+++ b/Recurly/Response.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Net;
 using RestSharp;
@@ -7,9 +8,22 @@ namespace Recurly
     public class Response
     {
         public string RawResponse { get; set; }
+
         public HttpStatusCode StatusCode { get; set; }
 
         public IList<Parameter> Headers { get; set; }
+
+        public string RequestId { get { return GetHeader("X-Request-Id"); } }
+
+        public int? RateLimit { get { return GetIntHeader("X-RateLimit-Limit"); } }
+
+        public int? RateLimitRemaining { get { return GetIntHeader("X-RateLimit-Remaining"); } }
+
+        public int? RateLimitReset { get { return GetIntHeader("X-RateLimit-Reset"); } }
+
+        public string ContentType { get { return GetHeader("Content-Type"); } }
+
+        public int? RecordCount { get { return GetIntHeader("Recurly-Total-Records"); } }
 
         public Response() { }
 
@@ -21,6 +35,29 @@ namespace Recurly
                 StatusCode = resp.StatusCode,
                 Headers = resp.Headers
             };
+        }
+
+        private string GetHeader(string name)
+        {
+            foreach (var header in Headers)
+                if (header.Name == name)
+                    return (string)header.Value;
+            return null;
+        }
+
+        private int? GetIntHeader(string name)
+        {
+            var header = GetHeader(name);
+            if (header is null)
+                return null;
+            try
+            {
+                return Int32.Parse(header);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
         }
 
     }

--- a/Recurly/Response.cs
+++ b/Recurly/Response.cs
@@ -11,7 +11,7 @@ namespace Recurly
 
         public HttpStatusCode StatusCode { get; set; }
 
-        public IList<Parameter> Headers { get; set; }
+        public IList<Header> Headers { get; set; }
 
         public string RequestId { get { return GetHeader("X-Request-Id"); } }
 
@@ -29,11 +29,17 @@ namespace Recurly
 
         public static Response Build(IRestResponse resp)
         {
+            // Map List<Parameter> to List<Header>
+            var headers = new List<Header>();
+            foreach (var header in resp.Headers)
+            {
+                headers.Add(new Header(header.Name, (string)header.Value));
+            }
             return new Response()
             {
                 RawResponse = resp.Content,
                 StatusCode = resp.StatusCode,
-                Headers = resp.Headers
+                Headers = headers,
             };
         }
 
@@ -41,7 +47,7 @@ namespace Recurly
         {
             foreach (var header in Headers)
                 if (header.Name == name)
-                    return (string)header.Value;
+                    return header.Value;
             return null;
         }
 
@@ -60,5 +66,17 @@ namespace Recurly
             }
         }
 
+    }
+
+    public class Header
+    {
+        public string Name { get; set; }
+        public string Value { get; set; }
+
+        public Header(string name, string value)
+        {
+            Name = name;
+            Value = value;
+        }
     }
 }

--- a/Recurly/Response.cs
+++ b/Recurly/Response.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Net;
+using RestSharp;
+
+namespace Recurly
+{
+    public class Response
+    {
+        public string RawResponse { get; set; }
+        public HttpStatusCode StatusCode { get; set; }
+
+        public IList<Parameter> Headers { get; set; }
+
+        public Response() { }
+
+        public static Response Build(IRestResponse resp)
+        {
+            return new Response()
+            {
+                RawResponse = resp.Content,
+                StatusCode = resp.StatusCode,
+                Headers = resp.Headers
+            };
+        }
+
+    }
+}


### PR DESCRIPTION
The Response class is used to expose information about the response from Recurly API to the developer.
- The `Headers` property contains a List containing all of the response headers as Parameter objects.
- The `StatusCode` property contains the `HttpStatusCode` for the response.
- The `RawResponse` property contains the raw json response as a string.