### PR TITLE
BECS support

### DIFF
--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -121,7 +121,12 @@ namespace Recurly
         public string SortCode { get; set; }
 
         /// <summary>
-        /// The payment method type for a non-credit card based billing info. The value of `bacs` is the only accepted value (Bacs only)
+        /// Bank identifier code for AU based banks. Required for Becs based billing infos. (Becs only)
+        /// </summary>
+        public string BsbCode { get; set; }
+
+        /// <summary>
+        /// The payment method type for a non-credit card based billing info. `becs` and `bacs` are the only accepted values (Bacs and Becs only)
         /// </summary>
         public string Type { get; set; }
 
@@ -371,6 +376,10 @@ namespace Recurly
                         SortCode = reader.ReadElementContentAsString();
                         break;
 
+                    case "bsb_code":
+                        BsbCode = reader.ReadElementContentAsString();
+                        break;
+
                     case "type":
                         Type = reader.ReadElementContentAsString();
                         break;
@@ -447,10 +456,19 @@ namespace Recurly
                     xmlWriter.WriteElementString("account_type", AccountType.ToString().EnumNameToTransportCase());
                 }
 
+                if (!Type.IsNullOrEmpty())
+                {
+                  xmlWriter.WriteElementString("type", Type);
+                }
+
                 if (!SortCode.IsNullOrEmpty())
                 {
                   xmlWriter.WriteElementString("sort_code", SortCode);
-                  xmlWriter.WriteElementString("type", Type);
+                }
+
+                if (!BsbCode.IsNullOrEmpty())
+                {
+                  xmlWriter.WriteElementString("bsb_code", BsbCode);
                 }
 
                 if (!Iban.IsNullOrEmpty())

--- a/Test/BillingInfoTest.cs
+++ b/Test/BillingInfoTest.cs
@@ -137,7 +137,32 @@ namespace Recurly.Test
             }
             threw.Should().Be(true);
         }
-            
+
+        [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void CreateBillingInfoWithBecs()
+        {
+            var account = CreateNewAccount();
+            var becsInfo = new BillingInfo(account)
+            {
+                NameOnAccount = "Becs account name",
+                Address1 = "123 Test St",
+                Address2 = "The Test Cut",
+                City = "Adelaide",
+                Country = "AU",
+                AccountNumber = "12345678",
+                BsbCode = "082-082",
+                Type = "becs",
+            };
+            var threw = false;
+            try {
+                becsInfo.Create();
+            } catch (ValidationException exception) {
+                threw = true;
+                exception.Errors[0].Symbol.Should().Be("card_type_not_accepted");
+            }
+            threw.Should().Be(true);
+        }
+
         [RecurlyFact(TestEnvironment.Type.Integration)]
         public void LookupBillingInfo()
         {


### PR DESCRIPTION
Completed:

- Added `bsb_code` field
- Included test

Affects the following endpoints:
- `PUT /v2/accounts/{account_id}/billing_info`
- `PUT /v2/accounts/{account_id}`
- `POST /v2/accounts`
- `POST /v2/purchases`
- `POST /v2/purchases/preview`
- `POST /v2/subscriptions`

To create billing_info with BECS:
```c#
var info = new BillingInfo(account);
info.NameOnAccount = "Account Name";
info.Address1 = "123 Main St";
info.City = "Adelaide";
info.Country = "AU";
info.PostalCode = "W1K 6AH";
info.AccountNumber = "11223311";
info.BsbCode = "082-082";
info.Type = "becs";
info.Create();
```