### PR TITLE
Release 1.17.6

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,7 +1,16 @@
 Unreleased
 ===============
 
+1.17.6 (stable) / 2020-07-22
+===============
+This brings us up to API version 2.28. There are no breaking changes.
+
+- BECS support [PR](https://github.com/recurly/recurly-client-dotnet/pull/552)
+
 1.17.5 (stable) / 2020-06-30
+===============
+This brings us up to API version 2.27. There are no breaking changes.
+
 - Update serializer for item-backed add-ons to accommodate QBP [PR](https://github.com/recurly/recurly-client-dotnet/pull/515)
 - Add timeframe query params to cancel subscription endpoint [PR](https://github.com/recurly/recurly-client-dotnet/pull/525)
 - BACS support [PR](https://github.com/recurly/recurly-client-dotnet/pull/528)

--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -121,7 +121,12 @@ namespace Recurly
         public string SortCode { get; set; }
 
         /// <summary>
-        /// The payment method type for a non-credit card based billing info. The value of `bacs` is the only accepted value (Bacs only)
+        /// Bank identifier code for AU based banks. Required for Becs based billing infos. (Becs only)
+        /// </summary>
+        public string BsbCode { get; set; }
+
+        /// <summary>
+        /// The payment method type for a non-credit card based billing info. `becs` and `bacs` are the only accepted values (Bacs and Becs only)
         /// </summary>
         public string Type { get; set; }
 
@@ -371,6 +376,10 @@ namespace Recurly
                         SortCode = reader.ReadElementContentAsString();
                         break;
 
+                    case "bsb_code":
+                        BsbCode = reader.ReadElementContentAsString();
+                        break;
+
                     case "type":
                         Type = reader.ReadElementContentAsString();
                         break;
@@ -447,10 +456,19 @@ namespace Recurly
                     xmlWriter.WriteElementString("account_type", AccountType.ToString().EnumNameToTransportCase());
                 }
 
+                if (!Type.IsNullOrEmpty())
+                {
+                  xmlWriter.WriteElementString("type", Type);
+                }
+
                 if (!SortCode.IsNullOrEmpty())
                 {
                   xmlWriter.WriteElementString("sort_code", SortCode);
-                  xmlWriter.WriteElementString("type", Type);
+                }
+
+                if (!BsbCode.IsNullOrEmpty())
+                {
+                  xmlWriter.WriteElementString("bsb_code", BsbCode);
                 }
 
                 if (!Iban.IsNullOrEmpty())

--- a/Library/Configuration/Settings.cs
+++ b/Library/Configuration/Settings.cs
@@ -78,7 +78,7 @@ namespace Recurly.Configuration
         }
 
         protected const string RecurlyServerUri = "https://{0}.recurly.com/v2{1}";
-        public const string RecurlyApiVersion = "2.27";
+        public const string RecurlyApiVersion = "2.28";
         public const string ValidDomain = ".recurly.com";
 
         // static, unlikely to change

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.17.5.0")]
-[assembly: AssemblyFileVersion("1.17.5.0")]
+[assembly: AssemblyVersion("1.17.6.0")]
+[assembly: AssemblyFileVersion("1.17.6.0")]

--- a/Test/BillingInfoTest.cs
+++ b/Test/BillingInfoTest.cs
@@ -137,7 +137,32 @@ namespace Recurly.Test
             }
             threw.Should().Be(true);
         }
-            
+
+        [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void CreateBillingInfoWithBecs()
+        {
+            var account = CreateNewAccount();
+            var becsInfo = new BillingInfo(account)
+            {
+                NameOnAccount = "Becs account name",
+                Address1 = "123 Test St",
+                Address2 = "The Test Cut",
+                City = "Adelaide",
+                Country = "AU",
+                AccountNumber = "12345678",
+                BsbCode = "082-082",
+                Type = "becs",
+            };
+            var threw = false;
+            try {
+                becsInfo.Create();
+            } catch (ValidationException exception) {
+                threw = true;
+                exception.Errors[0].Symbol.Should().Be("card_type_not_accepted");
+            }
+            threw.Should().Be(true);
+        }
+
         [RecurlyFact(TestEnvironment.Type.Integration)]
         public void LookupBillingInfo()
         {

--- a/dist/recurly.nuspec
+++ b/dist/recurly.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>recurly-api-client</id>
-    <version>1.17.5</version>
+    <version>1.17.6</version>
     <authors>recurly</authors>
     <owners>recurly</owners>
     <licenseUrl>https://github.com/recurly/recurly-client-net/blob/master/LICENSE.txt</licenseUrl>


### PR DESCRIPTION
This brings us up to API version 2.28. There are no breaking changes.

- BECS support https://github.com/recurly/recurly-client-dotnet/pull/552