### PR TITLE
Namespaces Response and Header

### DIFF
--- a/Recurly.Tests/HttpTest.cs
+++ b/Recurly.Tests/HttpTest.cs
@@ -2,12 +2,13 @@ using System;
 using System.Collections.Generic;
 using Moq;
 using Recurly;
+using Recurly.Http;
 using RestSharp;
 using Xunit;
 
 namespace Recurly.Tests
 {
-    public class ResponseTest
+    public class HttpTest
     {
         private IList<Header> TestHeaders = new List<Header>()
         {
@@ -19,7 +20,7 @@ namespace Recurly.Tests
             new Header("Recurly-Total-Records", "42"),
         };
 
-        public ResponseTest() { }
+        public HttpTest() { }
 
         [Fact]
         public void CanGetStatusCode()

--- a/Recurly/BaseClient.cs
+++ b/Recurly/BaseClient.cs
@@ -59,7 +59,7 @@ namespace Recurly
                 var resp = t.Result;
                 this.HandleResponse(resp);
                 if (resp.Data is Resource)
-                    resp.Data.SetResponse(Response.Build(resp));
+                    resp.Data.SetResponse(Http.Response.Build(resp));
                 return resp.Data;
             });
         }
@@ -71,7 +71,7 @@ namespace Recurly
             var resp = RestClient.Execute<T>(request);
             this.HandleResponse(resp);
             if (resp.Data is Resource)
-                resp.Data.SetResponse(Response.Build(resp));
+                resp.Data.SetResponse(Http.Response.Build(resp));
             return resp.Data;
         }
 

--- a/Recurly/Http.cs
+++ b/Recurly/Http.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using RestSharp;
 
-namespace Recurly
+namespace Recurly.Http
 {
     public class Response
     {

--- a/Recurly/Resource.cs
+++ b/Recurly/Resource.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Recurly.Http;
 
 namespace Recurly
 {


### PR DESCRIPTION
This namespaces the `Response` and `Header` classes from #549 

It will also be used to house `Request` (which conflicts with Recurly.Request). Request will be added in a follow up PR.

This technically would be a breaking change but we have not released changes from #549 yet so it's safe.