### PR TITLE
Account for when usage_percentage is null

### DIFF
--- a/Library/AddOn.cs
+++ b/Library/AddOn.cs
@@ -207,7 +207,9 @@ namespace Recurly
                         break;
 
                     case "usage_percentage":
-                        UsagePercentage = reader.ReadElementContentAsFloat();
+                        if (reader.GetAttribute("nil") == null) {
+                            UsagePercentage = reader.ReadElementContentAsFloat();
+                        }
                         break;
 
                     case "revenue_schedule_type":


### PR DESCRIPTION
Addresses issue where `usage_percentage` is parsed with nil value.

```
System.FormatException: Input string was not in a correct format.
   at System.Number.ParseSingle(ReadOnlySpan`1 value, NumberStyles options, NumberFormatInfo numfmt)
   at System.Single.Parse(String s, NumberStyles style, IFormatProvider provider)
   at System.Xml.XmlConvert.ToSingle(String s)
   at System.Xml.XmlReader.ReadElementContentAsFloat()
   at Recurly.AddOn.ReadXml(XmlTextReader reader)
```

There are two previous PRs that address the issue of when <usage_percentage> is null: [one](https://github.com/recurly/recurly-client-dotnet/pull/376) for `SubscriptionAddOn` and [one](https://github.com/recurly/recurly-client-dotnet/pull/169) for `Usage`. This PR applies to `AddOn`.