### PR TITLE
To enable updating QBP sub add-ons, add Tiers to SubscriptionAddOn

### DIFF
--- a/Library/List/SubscriptionAddOnList.cs
+++ b/Library/List/SubscriptionAddOnList.cs
@@ -118,9 +118,26 @@ namespace Recurly
         /// <param name="tierType">The add-on tier-type.</param>
         /// <param name="quantity">The quantity of the add-on. Optional, default is 1.</param>
 
-        public void Add(AddOn planAddOn, string tierType, int quantity)
+        public void Add(AddOn planAddOn, string tierType, int quantity=1)
         {
             var sub = new SubscriptionAddOn(planAddOn.AddOnCode, tierType, quantity);
+            base.Add(sub);
+        }
+
+        /// <summary>
+        /// Adds subscription add-on to SubscriptionChange
+        /// 
+        /// Sample usage:
+        /// <code>
+        /// var change = new SubscriptionChange {
+        ///  TimeFrame = SubscriptionChange.ChangeTimeframe.Now,
+        ///  AddOns = new SubscriptionAddOnList(subscription)
+        /// };
+        /// change.AddOns.Add(subaddon); 
+
+        public void Add(SubscriptionAddOn addOn)
+        {
+            var sub = addOn;
             base.Add(sub);
         }
 

--- a/Library/SubscriptionAddOn.cs
+++ b/Library/SubscriptionAddOn.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Xml;
 using System.Globalization;
+using System.Collections.Generic;
 
 namespace Recurly
 {
@@ -13,6 +14,18 @@ namespace Recurly
         public Adjustment.RevenueSchedule? RevenueScheduleType { get; set; }
         public float? UsagePercentage { get; set; }
         public string TierType { get; set; }
+
+        private List<Tier> _tiers; 
+
+        /// <summary>
+        /// List of tiers for this add-on
+        /// </summary>
+        public List<Tier> Tiers
+        {
+            get {return _tiers ?? (_tiers = new List<Tier>()); }
+            set { _tiers = value; }
+        }
+
         public string AddOnSource { get; set; }
 
         public SubscriptionAddOn(XmlTextReader reader)
@@ -100,6 +113,20 @@ namespace Recurly
                         TierType = reader.ReadElementContentAsString();
                         break;
 
+                    case "tiers":
+                        Tiers = new List<Tier>();
+                        while (reader.Read())
+                        {
+                            if (reader.Name == "tiers" && reader.NodeType == XmlNodeType.EndElement)
+                                break;
+
+                            if (reader.NodeType == XmlNodeType.Element && reader.Name == "tier")
+                            {
+                                Tiers.Add(new Tier(reader));
+                            }
+                        }
+                        break;
+
                     case "add_on_source":
                         AddOnSource = reader.ReadElementContentAsString();
                         break;
@@ -126,6 +153,8 @@ namespace Recurly
 
             if (TierType != null)
                 writer.WriteElementString("tier_type", TierType);
+
+            writer.WriteIfCollectionHasAny("tiers", Tiers);
 
             if (AddOnSource != null)
                 writer.WriteElementString("add_on_source", AddOnSource);


### PR DESCRIPTION
Note that this change will trigger the following error because `unit_amount_in_cents` is sent as a dictionary of currencies and values instead of as an `Integer`. This error will be addressed in a separate ticket. `The provided XML was invalid. | Field: "" Code: "" Symbol: "invalid_xml" Details: "Tag <unit_amount_in_cents> must contain only text"`

Sample code:
```c#
var subscription = Subscriptions.Get(subscription.Uuid);
var change = new SubscriptionChange {
  TimeFrame = SubscriptionChange.ChangeTimeframe.Now,
  AddOns = new SubscriptionAddOnList()
};

SubscriptionAddOn subaddon = subscription.AddOns[0];

var tier1 = subaddon.Tiers[0];
tier1.UnitAmountInCents.Add("USD", 99);
tier1.EndingQuantity = 11;

change.AddOns.Add(subaddon); 

Subscription.ChangeSubscription(subscription.Uuid, change);
```