### PR TITLE
Add tax identifier fields to billing info

### DIFF
--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -132,6 +132,16 @@ namespace Recurly
 
         public string TransactionType { get; set; }
 
+        /// <summary>
+        /// Tax identifier is required if adding a billing info that is a consumer card in Brazil.
+        /// </summary>
+        public string TaxIdentifier { get; set; }
+
+        /// <summary>
+        /// This field and a value of 'cpf' are required if adding a billing info that is an elo or hipercard type in Brazil.
+        /// </summary>
+        public string TaxIdentifierType { get; set; }
+
         private string _cardNumber;
 
         /// <summary>
@@ -384,6 +394,14 @@ namespace Recurly
                         Type = reader.ReadElementContentAsString();
                         break;
 
+                    case "tax_identifier":
+                        TaxIdentifier = reader.ReadElementContentAsString();
+                        break;
+
+                    case "tax_identifier_type":
+                        TaxIdentifierType = reader.ReadElementContentAsString();
+                        break;
+
                     case "account_type":
                         var accountType = reader.ReadElementContentAsString();
                         if (!accountType.IsNullOrEmpty())
@@ -430,6 +448,8 @@ namespace Recurly
                 xmlWriter.WriteStringIfValid("phone", PhoneNumber);
                 xmlWriter.WriteStringIfValid("vat_number", VatNumber);
                 xmlWriter.WriteStringIfValid("currency", Currency);
+                xmlWriter.WriteStringIfValid("tax_identifier", TaxIdentifier);
+                xmlWriter.WriteStringIfValid("tax_identifier_type", TaxIdentifierType);
 
                 if (!IpAddress.IsNullOrEmpty())
                     xmlWriter.WriteElementString("ip_address", IpAddress);


### PR DESCRIPTION
Allows merchants to specify individual tax identifiers for customers (CPF + Brazil support) when creating and updating billing information.

Two fields introduced:
`tax_identifier`
`tax_identifier_type`

Example code:
```c#
var info = new BillingInfo(account);
info.FirstName = "Rotini";
info.LastName = "Du Monde";
info.Address1 = "123 Main St";
info.City = "New Orleans";
info.State = "LA";
info.Country = "US";
info.PostalCode = "70212";
info.CreditCardNumber = "4111111111111111";
info.ExpirationMonth = 10;
info.ExpirationYear = 2046;
info.TaxIdentifier = "758.356.352-65";
info.TaxIdentifierType = "cpf";
info.Create();
```