### PR TITLE
Return EmptyResource

### DIFF
--- a/Recurly/Client.cs
+++ b/Recurly/Client.cs
@@ -322,11 +322,11 @@ namespace Recurly
         /// Acquisition data was succesfully deleted.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        public void RemoveAccountAcquisition(string accountId, RequestOptions options = null)
+        public EmptyResource RemoveAccountAcquisition(string accountId, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "account_id", accountId } };
             var url = this.InterpolatePath("/accounts/{account_id}/acquisition", urlParams);
-            MakeRequest<EmptyResource>(Method.DELETE, url, null, null, options);
+            return MakeRequest<EmptyResource>(Method.DELETE, url, null, null, options);
         }
 
 
@@ -494,11 +494,11 @@ namespace Recurly
         /// Billing information deleted
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        public void RemoveBillingInfo(string accountId, RequestOptions options = null)
+        public EmptyResource RemoveBillingInfo(string accountId, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "account_id", accountId } };
             var url = this.InterpolatePath("/accounts/{account_id}/billing_info", urlParams);
-            MakeRequest<EmptyResource>(Method.DELETE, url, null, null, options);
+            return MakeRequest<EmptyResource>(Method.DELETE, url, null, null, options);
         }
 
 
@@ -1033,11 +1033,11 @@ namespace Recurly
         /// Shipping address deleted.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        public void RemoveShippingAddress(string accountId, string shippingAddressId, RequestOptions options = null)
+        public EmptyResource RemoveShippingAddress(string accountId, string shippingAddressId, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "account_id", accountId }, { "shipping_address_id", shippingAddressId } };
             var url = this.InterpolatePath("/accounts/{account_id}/shipping_addresses/{shipping_address_id}", urlParams);
-            MakeRequest<EmptyResource>(Method.DELETE, url, null, null, options);
+            return MakeRequest<EmptyResource>(Method.DELETE, url, null, null, options);
         }
 
 
@@ -2337,11 +2337,11 @@ namespace Recurly
         /// Line item deleted.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        public void RemoveLineItem(string lineItemId, RequestOptions options = null)
+        public EmptyResource RemoveLineItem(string lineItemId, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "line_item_id", lineItemId } };
             var url = this.InterpolatePath("/line_items/{line_item_id}", urlParams);
-            MakeRequest<EmptyResource>(Method.DELETE, url, null, null, options);
+            return MakeRequest<EmptyResource>(Method.DELETE, url, null, null, options);
         }
 
 
@@ -3336,11 +3336,11 @@ namespace Recurly
         /// Subscription change was deleted.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        public void RemoveSubscriptionChange(string subscriptionId, RequestOptions options = null)
+        public EmptyResource RemoveSubscriptionChange(string subscriptionId, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "subscription_id", subscriptionId } };
             var url = this.InterpolatePath("/subscriptions/{subscription_id}/change", urlParams);
-            MakeRequest<EmptyResource>(Method.DELETE, url, null, null, options);
+            return MakeRequest<EmptyResource>(Method.DELETE, url, null, null, options);
         }
 
 
@@ -3618,11 +3618,11 @@ namespace Recurly
         /// Usage was successfully deleted.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        public void RemoveUsage(string usageId, RequestOptions options = null)
+        public EmptyResource RemoveUsage(string usageId, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "usage_id", usageId } };
             var url = this.InterpolatePath("/usage/{usage_id}", urlParams);
-            MakeRequest<EmptyResource>(Method.DELETE, url, null, null, options);
+            return MakeRequest<EmptyResource>(Method.DELETE, url, null, null, options);
         }
 
 

--- a/Recurly/IClient.cs
+++ b/Recurly/IClient.cs
@@ -200,7 +200,7 @@ namespace Recurly
         /// Acquisition data was succesfully deleted.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        void RemoveAccountAcquisition(string accountId, RequestOptions options = null);
+        EmptyResource RemoveAccountAcquisition(string accountId, RequestOptions options = null);
 
         /// <summary>
         /// Remove an account's acquisition data <see href="https://developers.recurly.com/api/v2020-01-01#operation/remove_account_acquisition">remove_account_acquisition api documentation</see>
@@ -302,7 +302,7 @@ namespace Recurly
         /// Billing information deleted
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        void RemoveBillingInfo(string accountId, RequestOptions options = null);
+        EmptyResource RemoveBillingInfo(string accountId, RequestOptions options = null);
 
         /// <summary>
         /// Remove an account's billing information <see href="https://developers.recurly.com/api/v2020-01-01#operation/remove_billing_info">remove_billing_info api documentation</see>
@@ -633,7 +633,7 @@ namespace Recurly
         /// Shipping address deleted.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        void RemoveShippingAddress(string accountId, string shippingAddressId, RequestOptions options = null);
+        EmptyResource RemoveShippingAddress(string accountId, string shippingAddressId, RequestOptions options = null);
 
         /// <summary>
         /// Remove an account's shipping address <see href="https://developers.recurly.com/api/v2020-01-01#operation/remove_shipping_address">remove_shipping_address api documentation</see>
@@ -1425,7 +1425,7 @@ namespace Recurly
         /// Line item deleted.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        void RemoveLineItem(string lineItemId, RequestOptions options = null);
+        EmptyResource RemoveLineItem(string lineItemId, RequestOptions options = null);
 
         /// <summary>
         /// Delete an uninvoiced line item <see href="https://developers.recurly.com/api/v2020-01-01#operation/remove_line_item">remove_line_item api documentation</see>
@@ -2027,7 +2027,7 @@ namespace Recurly
         /// Subscription change was deleted.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        void RemoveSubscriptionChange(string subscriptionId, RequestOptions options = null);
+        EmptyResource RemoveSubscriptionChange(string subscriptionId, RequestOptions options = null);
 
         /// <summary>
         /// Delete the pending subscription change <see href="https://developers.recurly.com/api/v2020-01-01#operation/remove_subscription_change">remove_subscription_change api documentation</see>
@@ -2203,7 +2203,7 @@ namespace Recurly
         /// Usage was successfully deleted.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        void RemoveUsage(string usageId, RequestOptions options = null);
+        EmptyResource RemoveUsage(string usageId, RequestOptions options = null);
 
         /// <summary>
         /// Delete a usage record. <see href="https://developers.recurly.com/api/v2020-01-01#operation/remove_usage">remove_usage api documentation</see>


### PR DESCRIPTION
Returning the `Empty` response object over `void` so the programmer can get at the response metadata. This breaks the contract for `IClient` so if anyone has implemented that interface, they will need to change it to return an `EmptyResource`.

This is technically a breaking change and should be called out in the release notes.