### PR TITLE
Write xml for address2 field as long as it is not null

### DIFF
--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -422,7 +422,7 @@ namespace Recurly
                 xmlWriter.WriteStringIfValid("company", Company);
                 xmlWriter.WriteStringIfValid("name_on_account", NameOnAccount);
                 xmlWriter.WriteStringIfValid("address1", Address1);
-                xmlWriter.WriteStringIfValid("address2", Address2);
+                if (Address2 != null) xmlWriter.WriteElementString("address2", Address2);
                 xmlWriter.WriteStringIfValid("city", City);
                 xmlWriter.WriteStringIfValid("state", State);
                 xmlWriter.WriteStringIfValid("zip", PostalCode);


### PR DESCRIPTION
Reported issue:
The Address2 field in the BillingInfo object cannot be cleared by sending an empty string ("").
```c#
var account = Accounts.Get("account_code");
var info = new BillingInfo(account);
info.Address2 = ""; // Does not clear Address2
info.Update();
```