### PR TITLE
Release 1.17.7

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,7 +3,7 @@ Unreleased
 
 1.17.7 (stable) / 2020-08-20
 ===============
-This brings up to API version 2.29. There are no breaking changes.
+This brings us up to API version 2.29. There are no breaking changes.
 
 - Account for when usage_percentage is null [PR](https://github.com/recurly/recurly-client-dotnet/pull/559)
 - Add tax identifier fields to billing info [PR](https://github.com/recurly/recurly-client-dotnet/pull/563)

--- a/History.md
+++ b/History.md
@@ -1,6 +1,15 @@
 Unreleased
 ===============
 
+1.17.7 (stable) / 2020-08-20
+===============
+This brings up to API version 2.29. There are no breaking changes.
+
+- Account for when usage_percentage is null [PR](https://github.com/recurly/recurly-client-dotnet/pull/559)
+- Add tax identifier fields to billing info [PR](https://github.com/recurly/recurly-client-dotnet/pull/563)
+- Apply level of abstraction to xml writers by using WriteStringIfValid() [PR](https://github.com/recurly/recurly-client-dotnet/pull/564)
+- Write xml for address2 field as long as it is not null [PR](https://github.com/recurly/recurly-client-dotnet/pull/566)
+
 1.17.6 (stable) / 2020-07-22
 ===============
 This brings us up to API version 2.28. There are no breaking changes.

--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -132,6 +132,16 @@ namespace Recurly
 
         public string TransactionType { get; set; }
 
+        /// <summary>
+        /// Tax identifier is required if adding a billing info that is a consumer card in Brazil.
+        /// </summary>
+        public string TaxIdentifier { get; set; }
+
+        /// <summary>
+        /// This field and a value of 'cpf' are required if adding a billing info that is an elo or hipercard type in Brazil.
+        /// </summary>
+        public string TaxIdentifierType { get; set; }
+
         private string _cardNumber;
 
         /// <summary>
@@ -384,6 +394,14 @@ namespace Recurly
                         Type = reader.ReadElementContentAsString();
                         break;
 
+                    case "tax_identifier":
+                        TaxIdentifier = reader.ReadElementContentAsString();
+                        break;
+
+                    case "tax_identifier_type":
+                        TaxIdentifierType = reader.ReadElementContentAsString();
+                        break;
+
                     case "account_type":
                         var accountType = reader.ReadElementContentAsString();
                         if (!accountType.IsNullOrEmpty())
@@ -438,6 +456,8 @@ namespace Recurly
                 xmlWriter.WriteStringIfValid("paypal_billing_agreement_id", PaypalBillingAgreementId);
                 xmlWriter.WriteStringIfValid("amazon_billing_agreement_id", AmazonBillingAgreementId);
                 xmlWriter.WriteStringIfValid("amazon_region", AmazonRegion);
+                xmlWriter.WriteStringIfValid("tax_identifier", TaxIdentifier);
+                xmlWriter.WriteStringIfValid("tax_identifier_type", TaxIdentifierType);
 
                 if (!IpAddress.IsNullOrEmpty())
                     xmlWriter.WriteElementString("ip_address", IpAddress);

--- a/Library/Configuration/Settings.cs
+++ b/Library/Configuration/Settings.cs
@@ -78,7 +78,7 @@ namespace Recurly.Configuration
         }
 
         protected const string RecurlyServerUri = "https://{0}.recurly.com/v2{1}";
-        public const string RecurlyApiVersion = "2.28";
+        public const string RecurlyApiVersion = "2.29";
         public const string ValidDomain = ".recurly.com";
 
         // static, unlikely to change

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.17.6.0")]
-[assembly: AssemblyFileVersion("1.17.6.0")]
+[assembly: AssemblyVersion("1.17.7.0")]
+[assembly: AssemblyFileVersion("1.17.7.0")]

--- a/dist/recurly.nuspec
+++ b/dist/recurly.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>recurly-api-client</id>
-    <version>1.17.6</version>
+    <version>1.17.7</version>
     <authors>recurly</authors>
     <owners>recurly</owners>
     <licenseUrl>https://github.com/recurly/recurly-client-net/blob/master/LICENSE.txt</licenseUrl>


### PR DESCRIPTION
This PR merges v2.29 features into v2 branch for release and bumps the client library version to 1.17.7.

---

This brings up to API version 2.29. There are no breaking changes.

- Account for when usage_percentage is null https://github.com/recurly/recurly-client-dotnet/pull/559 (merged into v2 branch)
- Add tax identifier fields to billing info https://github.com/recurly/recurly-client-dotnet/pull/563
- Apply level of abstraction to xml writers by using WriteStringIfValid() https://github.com/recurly/recurly-client-dotnet/pull/564 (merged into v2 branch)
- Write xml for address2 field as long as it is not null https://github.com/recurly/recurly-client-dotnet/pull/566 (merged into v2 branch)