### PR TITLE
Fri Aug 21 16:21:53 UTC 2020 Upgrade API version v2019-10-10

### DIFF
--- a/Recurly/Client.cs
+++ b/Recurly/Client.cs
@@ -3480,6 +3480,7 @@ namespace Recurly
         /// </summary>
         /// <param name="subscriptionId">Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.</param>
         /// <param name="addOnId">Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.</param>
+        /// <param name="ids">Filter results by their IDs. Up to 200 IDs can be passed at once using  commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.    **Important notes:**    * The `ids` parameter cannot be used with any other ordering or filtering    parameters (`limit`, `order`, `sort`, `begin_time`, `end_time`, etc)  * Invalid or unknown IDs will be ignored, so you should check that the    results correspond to your request.  * Records are returned in an arbitrary order. Since results are all    returned at once you can sort the records yourself.  </param>
         /// <param name="limit">Limit number of records 1-200.</param>
         /// <param name="order">Sort order.</param>
         /// <param name="sort">Sort field. You *really* only want to sort by `usage_timestamp` in ascending  order. In descending order updated records will move behind the cursor and could  prevent some records from being returned.  </param>
@@ -3489,10 +3490,10 @@ namespace Recurly
         /// <returns>
         /// A list of the subscription add-on's usage records.
         /// </returns>
-        public Pager<Usage> ListUsage(string subscriptionId, string addOnId, int? limit = null, string order = null, string sort = null, DateTime? beginTime = null, DateTime? endTime = null, string billingStatus = null, RequestOptions options = null)
+        public Pager<Usage> ListUsage(string subscriptionId, string addOnId, string ids = null, int? limit = null, string order = null, string sort = null, DateTime? beginTime = null, DateTime? endTime = null, string billingStatus = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "subscription_id", subscriptionId }, { "add_on_id", addOnId } };
-            var queryParams = new Dictionary<string, object> { { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime }, { "billing_status", billingStatus } };
+            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime }, { "billing_status", billingStatus } };
             var url = this.InterpolatePath("/subscriptions/{subscription_id}/add_ons/{add_on_id}/usage", urlParams);
             return Pager<Usage>.Build(url, queryParams, options, this);
         }

--- a/Recurly/Errors/ApiErrors.cs
+++ b/Recurly/Errors/ApiErrors.cs
@@ -5,8 +5,8 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Recurly.Errors
 {

--- a/Recurly/IClient.cs
+++ b/Recurly/IClient.cs
@@ -2116,6 +2116,7 @@ namespace Recurly
         /// </summary>
         /// <param name="subscriptionId">Subscription ID or UUID. For ID no prefix is used e.g. `e28zov4fw0v2`. For UUID use prefix `uuid-`, e.g. `uuid-123457890`.</param>
         /// <param name="addOnId">Add-on ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-gold`.</param>
+        /// <param name="ids">Filter results by their IDs. Up to 200 IDs can be passed at once using  commas as separators, e.g. `ids=h1at4d57xlmy,gyqgg0d3v9n1,jrsm5b4yefg6`.    **Important notes:**    * The `ids` parameter cannot be used with any other ordering or filtering    parameters (`limit`, `order`, `sort`, `begin_time`, `end_time`, etc)  * Invalid or unknown IDs will be ignored, so you should check that the    results correspond to your request.  * Records are returned in an arbitrary order. Since results are all    returned at once you can sort the records yourself.  </param>
         /// <param name="limit">Limit number of records 1-200.</param>
         /// <param name="order">Sort order.</param>
         /// <param name="sort">Sort field. You *really* only want to sort by `usage_timestamp` in ascending  order. In descending order updated records will move behind the cursor and could  prevent some records from being returned.  </param>
@@ -2125,7 +2126,7 @@ namespace Recurly
         /// <returns>
         /// A list of the subscription add-on's usage records.
         /// </returns>
-        Pager<Usage> ListUsage(string subscriptionId, string addOnId, int? limit = null, string order = null, string sort = null, DateTime? beginTime = null, DateTime? endTime = null, string billingStatus = null, RequestOptions options = null);
+        Pager<Usage> ListUsage(string subscriptionId, string addOnId, string ids = null, int? limit = null, string order = null, string sort = null, DateTime? beginTime = null, DateTime? endTime = null, string billingStatus = null, RequestOptions options = null);
 
 
         /// <summary>

--- a/Recurly/Resources/AddOn.cs
+++ b/Recurly/Resources/AddOn.cs
@@ -23,6 +23,14 @@ namespace Recurly.Resources
         [JsonProperty("add_on_type")]
         public string AddOnType { get; set; }
 
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the add-on is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_service_type")]
+        public int? AvalaraServiceType { get; set; }
+
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the add-on is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_transaction_type")]
+        public int? AvalaraTransactionType { get; set; }
+
         /// <value>The unique identifier for the add-on within its plan.</value>
         [JsonProperty("code")]
         public string Code { get; set; }

--- a/Recurly/Resources/AddOnCreate.cs
+++ b/Recurly/Resources/AddOnCreate.cs
@@ -23,6 +23,14 @@ namespace Recurly.Resources
         [JsonProperty("add_on_type")]
         public string AddOnType { get; set; }
 
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the add-on is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `AddOn`, then the `avalara_service_type` must be absent.</value>
+        [JsonProperty("avalara_service_type")]
+        public int? AvalaraServiceType { get; set; }
+
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the add-on is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `AddOn`, then the `avalara_transaction_type` must be absent.</value>
+        [JsonProperty("avalara_transaction_type")]
+        public int? AvalaraTransactionType { get; set; }
+
         /// <value>The unique identifier for the add-on within its plan. If `item_code`/`item_id` is part of the request then `code` must be absent. If `item_code`/`item_id` is not present `code` is required.</value>
         [JsonProperty("code")]
         public string Code { get; set; }

--- a/Recurly/Resources/AddOnUpdate.cs
+++ b/Recurly/Resources/AddOnUpdate.cs
@@ -19,6 +19,14 @@ namespace Recurly.Resources
         [JsonProperty("accounting_code")]
         public string AccountingCode { get; set; }
 
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the add-on is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `AddOn`, then the `avalara_service_type` must be absent.</value>
+        [JsonProperty("avalara_service_type")]
+        public int? AvalaraServiceType { get; set; }
+
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the add-on is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `AddOn`, then the `avalara_transaction_type` must be absent.</value>
+        [JsonProperty("avalara_transaction_type")]
+        public int? AvalaraTransactionType { get; set; }
+
         /// <value>The unique identifier for the add-on within its plan. If an `Item` is associated to the `AddOn` then `code` must be absent.</value>
         [JsonProperty("code")]
         public string Code { get; set; }

--- a/Recurly/Resources/Item.cs
+++ b/Recurly/Resources/Item.cs
@@ -19,6 +19,14 @@ namespace Recurly.Resources
         [JsonProperty("accounting_code")]
         public string AccountingCode { get; set; }
 
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_service_type")]
+        public int? AvalaraServiceType { get; set; }
+
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_transaction_type")]
+        public int? AvalaraTransactionType { get; set; }
+
         /// <value>Unique code to identify the item.</value>
         [JsonProperty("code")]
         public string Code { get; set; }

--- a/Recurly/Resources/ItemCreate.cs
+++ b/Recurly/Resources/ItemCreate.cs
@@ -19,6 +19,14 @@ namespace Recurly.Resources
         [JsonProperty("accounting_code")]
         public string AccountingCode { get; set; }
 
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_service_type")]
+        public int? AvalaraServiceType { get; set; }
+
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_transaction_type")]
+        public int? AvalaraTransactionType { get; set; }
+
         /// <value>Unique code to identify the item.</value>
         [JsonProperty("code")]
         public string Code { get; set; }

--- a/Recurly/Resources/ItemUpdate.cs
+++ b/Recurly/Resources/ItemUpdate.cs
@@ -19,6 +19,14 @@ namespace Recurly.Resources
         [JsonProperty("accounting_code")]
         public string AccountingCode { get; set; }
 
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_service_type")]
+        public int? AvalaraServiceType { get; set; }
+
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_transaction_type")]
+        public int? AvalaraTransactionType { get; set; }
+
         /// <value>Unique code to identify the item.</value>
         [JsonProperty("code")]
         public string Code { get; set; }

--- a/Recurly/Resources/LineItem.cs
+++ b/Recurly/Resources/LineItem.cs
@@ -35,6 +35,14 @@ namespace Recurly.Resources
         [JsonProperty("amount")]
         public float? Amount { get; set; }
 
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the line item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_service_type")]
+        public int? AvalaraServiceType { get; set; }
+
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the line item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_transaction_type")]
+        public int? AvalaraTransactionType { get; set; }
+
         /// <value>When the line item was created.</value>
         [JsonProperty("created_at")]
         public DateTime? CreatedAt { get; set; }

--- a/Recurly/Resources/LineItemCreate.cs
+++ b/Recurly/Resources/LineItemCreate.cs
@@ -19,6 +19,14 @@ namespace Recurly.Resources
         [JsonProperty("accounting_code")]
         public string AccountingCode { get; set; }
 
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the line item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `LineItem`, then the `avalara_service_type` must be absent.</value>
+        [JsonProperty("avalara_service_type")]
+        public int? AvalaraServiceType { get; set; }
+
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the line item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `LineItem`, then the `avalara_transaction_type` must be absent.</value>
+        [JsonProperty("avalara_transaction_type")]
+        public int? AvalaraTransactionType { get; set; }
+
         /// <value>The reason the credit was given when line item is `type=credit`. When the Credit Invoices feature is enabled, the value can be set and will default to `general`. When the Credit Invoices feature is not enabled, the value will always be `null`.</value>
         [JsonProperty("credit_reason_code")]
         public string CreditReasonCode { get; set; }

--- a/Recurly/Resources/Plan.cs
+++ b/Recurly/Resources/Plan.cs
@@ -31,6 +31,14 @@ namespace Recurly.Resources
         [JsonProperty("auto_renew")]
         public bool? AutoRenew { get; set; }
 
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the plan is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_service_type")]
+        public int? AvalaraServiceType { get; set; }
+
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the plan is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_transaction_type")]
+        public int? AvalaraTransactionType { get; set; }
+
         /// <value>Unique code to identify the plan. This is used in Hosted Payment Page URLs and in the invoice exports.</value>
         [JsonProperty("code")]
         public string Code { get; set; }

--- a/Recurly/Resources/PlanCreate.cs
+++ b/Recurly/Resources/PlanCreate.cs
@@ -35,6 +35,14 @@ namespace Recurly.Resources
         [JsonProperty("auto_renew")]
         public bool? AutoRenew { get; set; }
 
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the plan is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_service_type")]
+        public int? AvalaraServiceType { get; set; }
+
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the plan is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_transaction_type")]
+        public int? AvalaraTransactionType { get; set; }
+
         /// <value>Unique code to identify the plan. This is used in Hosted Payment Page URLs and in the invoice exports.</value>
         [JsonProperty("code")]
         public string Code { get; set; }

--- a/Recurly/Resources/PlanUpdate.cs
+++ b/Recurly/Resources/PlanUpdate.cs
@@ -35,6 +35,14 @@ namespace Recurly.Resources
         [JsonProperty("auto_renew")]
         public bool? AutoRenew { get; set; }
 
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the plan is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_service_type")]
+        public int? AvalaraServiceType { get; set; }
+
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the plan is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_transaction_type")]
+        public int? AvalaraTransactionType { get; set; }
+
         /// <value>Unique code to identify the plan. This is used in Hosted Payment Page URLs and in the invoice exports.</value>
         [JsonProperty("code")]
         public string Code { get; set; }

--- a/Recurly/Resources/ShippingPurchase.cs
+++ b/Recurly/Resources/ShippingPurchase.cs
@@ -19,7 +19,7 @@ namespace Recurly.Resources
         [JsonProperty("address")]
         public ShippingAddressCreate Address { get; set; }
 
-        /// <value>Assign a shipping address from the account's existing shipping addresses. If this and `shipping_address` are both present, `shipping_address` will take precedence.</value>
+        /// <value>Assign a shipping address from the account's existing shipping addresses. If this and `address` are both present, `address` will take precedence.</value>
         [JsonProperty("address_id")]
         public string AddressId { get; set; }
 

--- a/Recurly/Resources/SubscriptionChangeCreate.cs
+++ b/Recurly/Resources/SubscriptionChangeCreate.cs
@@ -16,10 +16,11 @@ namespace Recurly.Resources
     {
 
         /// <value>
-        /// If you provide a value for this field it will replace any
-        /// existing add-ons. So, when adding or modifying an add-on, you need to
-        /// include the existing subscription add-ons. Unchanged add-ons can be included
-        /// just using the subscription add-on's ID: `{"id": "abc123"}`.
+        /// If this value is omitted your existing add-ons will be removed. If you provide
+        /// a value for this field it will replace any existing add-ons. So, when adding or
+        /// modifying an add-on, you need to include the existing subscription add-ons.
+        /// Unchanged add-ons can be included just using the subscription add-on's ID:
+        /// `{"id": "abc123"}`.
         /// 
         /// If a subscription add-on's `code` is supplied without the `id`,
         /// `{"code": "def456"}`, the subscription add-on attributes will be set to the

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -12650,6 +12650,7 @@ paths:
       - "$ref": "#/components/parameters/site_id"
       - "$ref": "#/components/parameters/subscription_id"
       - "$ref": "#/components/parameters/add_on_id"
+      - "$ref": "#/components/parameters/ids"
       - "$ref": "#/components/parameters/limit"
       - "$ref": "#/components/parameters/order"
       - "$ref": "#/components/parameters/usage_sort_dates"
@@ -14962,6 +14963,22 @@ components:
           - evenly
           - at_range_end
           - at_range_start
+        avalara_transaction_type:
+          type: integer
+          title: Avalara Transaction Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the add-on is taxed.
+            Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
+        avalara_service_type:
+          type: integer
+          title: Avalara Service Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the add-on is taxed.
+            Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
         tax_code:
           type: string
           title: Tax code
@@ -15153,6 +15170,24 @@ components:
             be included when a subscription is created through the Recurly UI. However,
             the add-on will not be included when a subscription is created through
             the API.
+        avalara_transaction_type:
+          type: integer
+          title: Avalara Transaction Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the add-on is taxed.
+            Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types. If an `Item` is associated to the `AddOn`,
+            then the `avalara_transaction_type` must be absent.
+          minimum: 0
+        avalara_service_type:
+          type: integer
+          title: Avalara Service Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the add-on is taxed.
+            Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types. If an `Item` is associated to the `AddOn`,
+            then the `avalara_service_type` must be absent.
+          minimum: 0
         tax_code:
           type: string
           title: Tax code
@@ -15266,6 +15301,24 @@ components:
           - evenly
           - at_range_end
           - at_range_start
+        avalara_transaction_type:
+          type: integer
+          title: Avalara Transaction Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the add-on is taxed.
+            Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types. If an `Item` is associated to the `AddOn`,
+            then the `avalara_transaction_type` must be absent.
+          minimum: 0
+        avalara_service_type:
+          type: integer
+          title: Avalara Service Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the add-on is taxed.
+            Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types. If an `Item` is associated to the `AddOn`,
+            then the `avalara_service_type` must be absent.
+          minimum: 0
         tax_code:
           type: string
           title: Tax code
@@ -16320,6 +16373,22 @@ components:
           - evenly
           - at_range_end
           - at_range_start
+        avalara_transaction_type:
+          type: integer
+          title: Avalara Transaction Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the item is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
+        avalara_service_type:
+          type: integer
+          title: Avalara Service Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the item is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
         tax_code:
           type: string
           title: Tax code
@@ -16393,6 +16462,22 @@ components:
           - evenly
           - at_range_end
           - at_range_start
+        avalara_transaction_type:
+          type: integer
+          title: Avalara Transaction Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the item is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
+        avalara_service_type:
+          type: integer
+          title: Avalara Service Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the item is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
         tax_code:
           type: string
           title: Tax code
@@ -16454,6 +16539,22 @@ components:
           - evenly
           - at_range_end
           - at_range_start
+        avalara_transaction_type:
+          type: integer
+          title: Avalara Transaction Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the item is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
+        avalara_service_type:
+          type: integer
+          title: Avalara Service Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the item is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
         tax_code:
           type: string
           title: Tax code
@@ -17254,6 +17355,22 @@ components:
             If not defined, then defaults to the Plan and Site settings. This attribute
             does not work for credits (negative line items). Credits are always applied
             post-tax. Pre-tax discounts should use the Coupons feature."
+        avalara_transaction_type:
+          type: integer
+          title: Avalara Transaction Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the line item is taxed.
+            Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
+        avalara_service_type:
+          type: integer
+          title: Avalara Service Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the line item is taxed.
+            Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
         tax_code:
           type: string
           title: Tax code
@@ -17419,6 +17536,24 @@ components:
             If not defined, then defaults to the Plan and Site settings. This attribute
             does not work for credits (negative line items). Credits are always applied
             post-tax. Pre-tax discounts should use the Coupons feature."
+        avalara_transaction_type:
+          type: integer
+          title: Avalara Transaction Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the line item is taxed.
+            Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types. If an `Item` is associated to the `LineItem`,
+            then the `avalara_transaction_type` must be absent.
+          minimum: 0
+        avalara_service_type:
+          type: integer
+          title: Avalara Service Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the line item is taxed.
+            Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types. If an `Item` is associated to the `LineItem`,
+            then the `avalara_service_type` must be absent.
+          minimum: 0
         tax_code:
           type: string
           title: Tax code
@@ -17607,6 +17742,22 @@ components:
             fee. If no value is provided, it defaults to plan's accounting code.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 20
+        avalara_transaction_type:
+          type: integer
+          title: Avalara Transaction Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the plan is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
+        avalara_service_type:
+          type: integer
+          title: Avalara Service Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the plan is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
         tax_code:
           type: string
           title: Tax code
@@ -17755,6 +17906,22 @@ components:
             fee. If no value is provided, it defaults to plan's accounting code.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 20
+        avalara_transaction_type:
+          type: integer
+          title: Avalara Transaction Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the plan is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
+        avalara_service_type:
+          type: integer
+          title: Avalara Service Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the plan is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
         tax_code:
           type: string
           title: Tax code
@@ -17934,6 +18101,22 @@ components:
             fee. If no value is provided, it defaults to plan's accounting code.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 20
+        avalara_transaction_type:
+          type: integer
+          title: Avalara Transaction Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the plan is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
+        avalara_service_type:
+          type: integer
+          title: Avalara Service Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the plan is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
         tax_code:
           type: string
           title: Tax code
@@ -19055,10 +19238,11 @@ components:
           type: array
           title: Add-ons
           description: |
-            If you provide a value for this field it will replace any
-            existing add-ons. So, when adding or modifying an add-on, you need to
-            include the existing subscription add-ons. Unchanged add-ons can be included
-            just using the subscription add-on's ID: `{"id": "abc123"}`.
+            If this value is omitted your existing add-ons will be removed. If you provide
+            a value for this field it will replace any existing add-ons. So, when adding or
+            modifying an add-on, you need to include the existing subscription add-ons.
+            Unchanged add-ons can be included just using the subscription add-on's ID:
+            `{"id": "abc123"}`.
 
             If a subscription add-on's `code` is supplied without the `id`,
             `{"code": "def456"}`, the subscription add-on attributes will be set to the
@@ -20119,8 +20303,8 @@ components:
               type: string
               title: Shipping address ID
               description: Assign a shipping address from the account's existing shipping
-                addresses. If this and `shipping_address` are both present, `shipping_address`
-                will take precedence.
+                addresses. If this and `address` are both present, `address` will
+                take precedence.
               maxLength: 13
             address:
               "$ref": "#/components/schemas/ShippingAddressCreate"
@@ -20312,6 +20496,7 @@ components:
                 title: Category
                 enum:
                 - 3d_secure_required
+                - 3d_secure_action_required
                 - amazon
                 - api_error
                 - approved


### PR DESCRIPTION
**This update introduces a potentially breaking change to the `ListUsage` method.**

A new parameter, `ids`, was introduced in Recurly API and the code generation process inserts this method parameter into the middle of the existing parameters. **This will NOT be a breaking change if you are using `Named Arguments`.**

- Adds the ability to filter Subscription Add-On Usage Records by `ids` on the list endpoint
- Adds Avalara support