### PR TITLE
Adding hierarchical errors and status code error generation

### DIFF
--- a/Recurly/BaseClient.cs
+++ b/Recurly/BaseClient.cs
@@ -154,7 +154,17 @@ namespace Recurly
             // has likely occurred
             if (resp.ErrorException != null)
             {
-                throw new RecurlyError(resp.ErrorMessage);
+                var message = !resp.ErrorException.Equals(null) ? resp.ErrorMessage : $"Unexpected {resp.StatusCode} Error.";
+                if (resp.Headers.Any(t => t.Name == "X-Request-ID"))
+                {
+                    var requestId = resp.Headers.ToList().Find(x => x.Name == "X-Request-ID").Value.ToString();
+                    message += $" Recurly Request Id: {requestId}";
+                }
+                var error = new Recurly.Resources.ErrorMayHaveTransaction()
+                {
+                    Message = message
+                };
+                throw Errors.Factory.Create(resp, message, error);
             }
             else if (status < 200 || status >= 300)
             {

--- a/Recurly/Errors/ApiErrors.cs
+++ b/Recurly/Errors/ApiErrors.cs
@@ -5,239 +5,258 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
-using System.Runtime.Serialization;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
 
 namespace Recurly.Errors
 {
 
+
     [ExcludeFromCodeCoverage]
-    public static class Factory
+    public class Response : ApiError
     {
-        public static ApiError Create(Recurly.Resources.ErrorMayHaveTransaction err)
-        {
-            switch (err.Type)
-            {
-                case Constants.ErrorType.BadRequest:
-                    return new BadRequest(err.Message)
-                    {
-                        Error = err
-                    };
-                case Constants.ErrorType.ImmutableSubscription:
-                    return new ImmutableSubscription(err.Message)
-                    {
-                        Error = err
-                    };
-                case Constants.ErrorType.InternalServerError:
-                    return new InternalServer(err.Message)
-                    {
-                        Error = err
-                    };
-                case Constants.ErrorType.InvalidApiKey:
-                    return new InvalidApiKey(err.Message)
-                    {
-                        Error = err
-                    };
-                case Constants.ErrorType.InvalidApiVersion:
-                    return new InvalidApiVersion(err.Message)
-                    {
-                        Error = err
-                    };
-                case Constants.ErrorType.InvalidContentType:
-                    return new InvalidContentType(err.Message)
-                    {
-                        Error = err
-                    };
-                case Constants.ErrorType.InvalidPermissions:
-                    return new InvalidPermissions(err.Message)
-                    {
-                        Error = err
-                    };
-                case Constants.ErrorType.InvalidToken:
-                    return new InvalidToken(err.Message)
-                    {
-                        Error = err
-                    };
-                case Constants.ErrorType.MissingFeature:
-                    return new MissingFeature(err.Message)
-                    {
-                        Error = err
-                    };
-                case Constants.ErrorType.NotFound:
-                    return new NotFound(err.Message)
-                    {
-                        Error = err
-                    };
-                case Constants.ErrorType.RateLimited:
-                    return new RateLimited(err.Message)
-                    {
-                        Error = err
-                    };
-                case Constants.ErrorType.SimultaneousRequest:
-                    return new SimultaneousRequest(err.Message)
-                    {
-                        Error = err
-                    };
-                case Constants.ErrorType.Transaction:
-                    return new Transaction(err.Message)
-                    {
-                        Error = err
-                    };
-                case Constants.ErrorType.Unauthorized:
-                    return new Unauthorized(err.Message)
-                    {
-                        Error = err
-                    };
-                case Constants.ErrorType.UnavailableInApiVersion:
-                    return new UnavailableInApiVersion(err.Message)
-                    {
-                        Error = err
-                    };
-                case Constants.ErrorType.UnknownApiVersion:
-                    return new UnknownApiVersion(err.Message)
-                    {
-                        Error = err
-                    };
-                case Constants.ErrorType.Validation:
-                    return new Validation(err.Message)
-                    {
-                        Error = err
-                    };
-                default:
-                    // Explode if we are in strict mode
-                    if (Utils.StrictMode)
-                    {
-                        throw new ArgumentException($"{err.Type} has no valid exception class");
-                    }
-                    // Fall back to generic API error if we are in production
-                    else
-                    {
-                        return new ApiError(err.Message)
-                        {
-                            Error = err
-                        };
-                    }
-            }
-        }
+        public Response() { }
+        public Response(string message) : base(message) { }
+        public Response(string message, Exception inner) : base(message, inner) { }
     }
 
     [ExcludeFromCodeCoverage]
-    public class BadRequest : ApiError
+    public class Server : Response
     {
-        public BadRequest() { }
-        public BadRequest(string message) : base(message) { }
-        public BadRequest(string message, Exception inner) : base(message, inner) { }
+        public Server() { }
+        public Server(string message) : base(message) { }
+        public Server(string message, Exception inner) : base(message, inner) { }
     }
+
     [ExcludeFromCodeCoverage]
-    public class ImmutableSubscription : ApiError
-    {
-        public ImmutableSubscription() { }
-        public ImmutableSubscription(string message) : base(message) { }
-        public ImmutableSubscription(string message, Exception inner) : base(message, inner) { }
-    }
-    [ExcludeFromCodeCoverage]
-    public class InternalServer : ApiError
+    public class InternalServer : Server
     {
         public InternalServer() { }
         public InternalServer(string message) : base(message) { }
         public InternalServer(string message, Exception inner) : base(message, inner) { }
     }
+
     [ExcludeFromCodeCoverage]
-    public class InvalidApiKey : ApiError
+    public class BadGateway : Server
     {
-        public InvalidApiKey() { }
-        public InvalidApiKey(string message) : base(message) { }
-        public InvalidApiKey(string message, Exception inner) : base(message, inner) { }
+        public BadGateway() { }
+        public BadGateway(string message) : base(message) { }
+        public BadGateway(string message, Exception inner) : base(message, inner) { }
     }
+
     [ExcludeFromCodeCoverage]
-    public class InvalidApiVersion : ApiError
+    public class ServiceUnavailable : Server
     {
-        public InvalidApiVersion() { }
-        public InvalidApiVersion(string message) : base(message) { }
-        public InvalidApiVersion(string message, Exception inner) : base(message, inner) { }
+        public ServiceUnavailable() { }
+        public ServiceUnavailable(string message) : base(message) { }
+        public ServiceUnavailable(string message, Exception inner) : base(message, inner) { }
     }
+
     [ExcludeFromCodeCoverage]
-    public class InvalidContentType : ApiError
+    public class Timeout : Server
+    {
+        public Timeout() { }
+        public Timeout(string message) : base(message) { }
+        public Timeout(string message, Exception inner) : base(message, inner) { }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class Redirection : Response
+    {
+        public Redirection() { }
+        public Redirection(string message) : base(message) { }
+        public Redirection(string message, Exception inner) : base(message, inner) { }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class NotModified : Response
+    {
+        public NotModified() { }
+        public NotModified(string message) : base(message) { }
+        public NotModified(string message, Exception inner) : base(message, inner) { }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class Client : ApiError
+    {
+        public Client() { }
+        public Client(string message) : base(message) { }
+        public Client(string message, Exception inner) : base(message, inner) { }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class BadRequest : Client
+    {
+        public BadRequest() { }
+        public BadRequest(string message) : base(message) { }
+        public BadRequest(string message, Exception inner) : base(message, inner) { }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class InvalidContentType : BadRequest
     {
         public InvalidContentType() { }
         public InvalidContentType(string message) : base(message) { }
         public InvalidContentType(string message, Exception inner) : base(message, inner) { }
     }
+
     [ExcludeFromCodeCoverage]
-    public class InvalidPermissions : ApiError
-    {
-        public InvalidPermissions() { }
-        public InvalidPermissions(string message) : base(message) { }
-        public InvalidPermissions(string message, Exception inner) : base(message, inner) { }
-    }
-    [ExcludeFromCodeCoverage]
-    public class InvalidToken : ApiError
-    {
-        public InvalidToken() { }
-        public InvalidToken(string message) : base(message) { }
-        public InvalidToken(string message, Exception inner) : base(message, inner) { }
-    }
-    [ExcludeFromCodeCoverage]
-    public class MissingFeature : ApiError
-    {
-        public MissingFeature() { }
-        public MissingFeature(string message) : base(message) { }
-        public MissingFeature(string message, Exception inner) : base(message, inner) { }
-    }
-    [ExcludeFromCodeCoverage]
-    public class NotFound : ApiError
-    {
-        public NotFound() { }
-        public NotFound(string message) : base(message) { }
-        public NotFound(string message, Exception inner) : base(message, inner) { }
-    }
-    [ExcludeFromCodeCoverage]
-    public class RateLimited : ApiError
-    {
-        public RateLimited() { }
-        public RateLimited(string message) : base(message) { }
-        public RateLimited(string message, Exception inner) : base(message, inner) { }
-    }
-    [ExcludeFromCodeCoverage]
-    public class SimultaneousRequest : ApiError
-    {
-        public SimultaneousRequest() { }
-        public SimultaneousRequest(string message) : base(message) { }
-        public SimultaneousRequest(string message, Exception inner) : base(message, inner) { }
-    }
-    [ExcludeFromCodeCoverage]
-    public class Transaction : ApiError
-    {
-        public Transaction() { }
-        public Transaction(string message) : base(message) { }
-        public Transaction(string message, Exception inner) : base(message, inner) { }
-    }
-    [ExcludeFromCodeCoverage]
-    public class Unauthorized : ApiError
+    public class Unauthorized : Client
     {
         public Unauthorized() { }
         public Unauthorized(string message) : base(message) { }
         public Unauthorized(string message, Exception inner) : base(message, inner) { }
     }
+
     [ExcludeFromCodeCoverage]
-    public class UnavailableInApiVersion : ApiError
+    public class PaymentRequired : Client
     {
-        public UnavailableInApiVersion() { }
-        public UnavailableInApiVersion(string message) : base(message) { }
-        public UnavailableInApiVersion(string message, Exception inner) : base(message, inner) { }
+        public PaymentRequired() { }
+        public PaymentRequired(string message) : base(message) { }
+        public PaymentRequired(string message, Exception inner) : base(message, inner) { }
     }
+
     [ExcludeFromCodeCoverage]
-    public class UnknownApiVersion : ApiError
+    public class Forbidden : Client
+    {
+        public Forbidden() { }
+        public Forbidden(string message) : base(message) { }
+        public Forbidden(string message, Exception inner) : base(message, inner) { }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class InvalidApiKey : Forbidden
+    {
+        public InvalidApiKey() { }
+        public InvalidApiKey(string message) : base(message) { }
+        public InvalidApiKey(string message, Exception inner) : base(message, inner) { }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class InvalidPermissions : Forbidden
+    {
+        public InvalidPermissions() { }
+        public InvalidPermissions(string message) : base(message) { }
+        public InvalidPermissions(string message, Exception inner) : base(message, inner) { }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class NotFound : Client
+    {
+        public NotFound() { }
+        public NotFound(string message) : base(message) { }
+        public NotFound(string message, Exception inner) : base(message, inner) { }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class NotAcceptable : Client
+    {
+        public NotAcceptable() { }
+        public NotAcceptable(string message) : base(message) { }
+        public NotAcceptable(string message, Exception inner) : base(message, inner) { }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class UnknownApiVersion : NotAcceptable
     {
         public UnknownApiVersion() { }
         public UnknownApiVersion(string message) : base(message) { }
         public UnknownApiVersion(string message, Exception inner) : base(message, inner) { }
     }
+
     [ExcludeFromCodeCoverage]
-    public class Validation : ApiError
+    public class UnavailableInApiVersion : NotAcceptable
+    {
+        public UnavailableInApiVersion() { }
+        public UnavailableInApiVersion(string message) : base(message) { }
+        public UnavailableInApiVersion(string message, Exception inner) : base(message, inner) { }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class InvalidApiVersion : NotAcceptable
+    {
+        public InvalidApiVersion() { }
+        public InvalidApiVersion(string message) : base(message) { }
+        public InvalidApiVersion(string message, Exception inner) : base(message, inner) { }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class PreconditionFailed : Client
+    {
+        public PreconditionFailed() { }
+        public PreconditionFailed(string message) : base(message) { }
+        public PreconditionFailed(string message, Exception inner) : base(message, inner) { }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class UnprocessableEntity : Client
+    {
+        public UnprocessableEntity() { }
+        public UnprocessableEntity(string message) : base(message) { }
+        public UnprocessableEntity(string message, Exception inner) : base(message, inner) { }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class Validation : UnprocessableEntity
     {
         public Validation() { }
         public Validation(string message) : base(message) { }
         public Validation(string message, Exception inner) : base(message, inner) { }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class MissingFeature : UnprocessableEntity
+    {
+        public MissingFeature() { }
+        public MissingFeature(string message) : base(message) { }
+        public MissingFeature(string message, Exception inner) : base(message, inner) { }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class Transaction : UnprocessableEntity
+    {
+        public Transaction() { }
+        public Transaction(string message) : base(message) { }
+        public Transaction(string message, Exception inner) : base(message, inner) { }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class SimultaneousRequest : UnprocessableEntity
+    {
+        public SimultaneousRequest() { }
+        public SimultaneousRequest(string message) : base(message) { }
+        public SimultaneousRequest(string message, Exception inner) : base(message, inner) { }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class ImmutableSubscription : UnprocessableEntity
+    {
+        public ImmutableSubscription() { }
+        public ImmutableSubscription(string message) : base(message) { }
+        public ImmutableSubscription(string message, Exception inner) : base(message, inner) { }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class InvalidToken : UnprocessableEntity
+    {
+        public InvalidToken() { }
+        public InvalidToken(string message) : base(message) { }
+        public InvalidToken(string message, Exception inner) : base(message, inner) { }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class TooManyRequests : Client
+    {
+        public TooManyRequests() { }
+        public TooManyRequests(string message) : base(message) { }
+        public TooManyRequests(string message, Exception inner) : base(message, inner) { }
+    }
+
+    [ExcludeFromCodeCoverage]
+    public class RateLimited : TooManyRequests
+    {
+        public RateLimited() { }
+        public RateLimited(string message) : base(message) { }
+        public RateLimited(string message, Exception inner) : base(message, inner) { }
     }
 }

--- a/Recurly/Errors/Factory.cs
+++ b/Recurly/Errors/Factory.cs
@@ -1,0 +1,204 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Runtime.Serialization;
+using RestSharp;
+
+namespace Recurly.Errors
+{
+
+    [ExcludeFromCodeCoverage]
+    public static class Factory
+    {
+        public static RecurlyError Create(IRestResponse resp, string message, Recurly.Resources.ErrorMayHaveTransaction nestedError)
+        {
+            switch ((int)resp.StatusCode)
+            {
+                case 500:
+                    return new InternalServer(message)
+                    {
+                        Error = nestedError
+                    };
+                case 502:
+                    return new BadGateway(message)
+                    {
+                        Error = nestedError
+                    };
+                case 503:
+                    return new ServiceUnavailable(message)
+                    {
+                        Error = nestedError
+                    };
+                case 504:
+                    return new Timeout(message)
+                    {
+                        Error = nestedError
+                    };
+                case 304:
+                    return new NotModified(message)
+                    {
+                        Error = nestedError
+                    };
+                case 400:
+                    return new BadRequest(message)
+                    {
+                        Error = nestedError
+                    };
+                case 401:
+                    return new Unauthorized(message)
+                    {
+                        Error = nestedError
+                    };
+                case 402:
+                    return new PaymentRequired(message)
+                    {
+                        Error = nestedError
+                    };
+                case 403:
+                    return new Forbidden(message)
+                    {
+                        Error = nestedError
+                    };
+                case 404:
+                    return new NotFound(message)
+                    {
+                        Error = nestedError
+                    };
+                case 406:
+                    return new NotAcceptable(message)
+                    {
+                        Error = nestedError
+                    };
+                case 412:
+                    return new PreconditionFailed(message)
+                    {
+                        Error = nestedError
+                    };
+                case 422:
+                    return new UnprocessableEntity(message)
+                    {
+                        Error = nestedError
+                    };
+                case 429:
+                    return new TooManyRequests(message)
+                    {
+                        Error = nestedError
+                    };
+                default:
+                    return new RecurlyError(resp.ErrorMessage);
+            }
+        }
+
+        public static ApiError Create(Recurly.Resources.ErrorMayHaveTransaction err)
+        {
+            switch (err.Type)
+            {
+                case Constants.ErrorType.BadRequest:
+                    return new BadRequest(err.Message)
+                    {
+                        Error = err
+                    };
+                case Constants.ErrorType.ImmutableSubscription:
+                    return new ImmutableSubscription(err.Message)
+                    {
+                        Error = err
+                    };
+                case Constants.ErrorType.InternalServerError:
+                    return new InternalServer(err.Message)
+                    {
+                        Error = err
+                    };
+                case Constants.ErrorType.InvalidApiKey:
+                    return new InvalidApiKey(err.Message)
+                    {
+                        Error = err
+                    };
+                case Constants.ErrorType.InvalidApiVersion:
+                    return new InvalidApiVersion(err.Message)
+                    {
+                        Error = err
+                    };
+                case Constants.ErrorType.InvalidContentType:
+                    return new InvalidContentType(err.Message)
+                    {
+                        Error = err
+                    };
+                case Constants.ErrorType.InvalidPermissions:
+                    return new InvalidPermissions(err.Message)
+                    {
+                        Error = err
+                    };
+                case Constants.ErrorType.InvalidToken:
+                    return new InvalidToken(err.Message)
+                    {
+                        Error = err
+                    };
+                case Constants.ErrorType.MissingFeature:
+                    return new MissingFeature(err.Message)
+                    {
+                        Error = err
+                    };
+                case Constants.ErrorType.NotFound:
+                    return new NotFound(err.Message)
+                    {
+                        Error = err
+                    };
+                case Constants.ErrorType.RateLimited:
+                    return new RateLimited(err.Message)
+                    {
+                        Error = err
+                    };
+                case Constants.ErrorType.SimultaneousRequest:
+                    return new SimultaneousRequest(err.Message)
+                    {
+                        Error = err
+                    };
+                case Constants.ErrorType.Transaction:
+                    return new Transaction(err.Message)
+                    {
+                        Error = err
+                    };
+                case Constants.ErrorType.Unauthorized:
+                    return new Unauthorized(err.Message)
+                    {
+                        Error = err
+                    };
+                case Constants.ErrorType.UnavailableInApiVersion:
+                    return new UnavailableInApiVersion(err.Message)
+                    {
+                        Error = err
+                    };
+                case Constants.ErrorType.UnknownApiVersion:
+                    return new UnknownApiVersion(err.Message)
+                    {
+                        Error = err
+                    };
+                case Constants.ErrorType.Validation:
+                    return new Validation(err.Message)
+                    {
+                        Error = err
+                    };
+                default:
+                    // Explode if we are in strict mode
+                    if (Utils.StrictMode)
+                    {
+                        throw new ArgumentException($"{err.Type} has no valid exception class");
+                    }
+                    // Fall back to generic API error if we are in production
+                    else
+                    {
+                        return new ApiError(err.Message)
+                        {
+                            Error = err
+                        };
+                    }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Non-breaking update to error classes to give them a hierarchical structure. This will facilitate differentiating between a `Error.Client` error and a `Errors.Server` error for example.

New error classes have also been added to be parent classes for some existing errors (e.g. `Errors.Forbidden` error is a new class and both `Errors.InvalidApiKey` error and `Errors.InvalidPermissions` error extend it).

Most importantly, this update allows the client library to gracefully handle non-json errors in the rare occasions when they occur. These errors will be based on the HTTP status code of the response and will fall back to the existing ApiError if there is not a defined mapping.

This is the `4.x` version of https://github.com/recurly/recurly-client-dotnet/pull/569
