### PR TITLE
Fixes deserialization of unknown enum values

### DIFF
--- a/Recurly.Tests/Fixtures.cs
+++ b/Recurly.Tests/Fixtures.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using Newtonsoft.Json;
 
 namespace Recurly.Tests
@@ -27,6 +28,10 @@ namespace Recurly.Tests
 
         [JsonProperty("my_array_sub_resource")]
         public List<MySubResource> MyArraySubResource { get; set; }
+
+        [JsonProperty("enum_value")]
+        [JsonConverter(typeof(RecurlyStringEnumConverter))]
+        public Recurly.Tests.Constants.EnumValue? EnumValue { get; set; }
     }
 
     public class MySubResource : Resource
@@ -46,6 +51,19 @@ namespace Recurly.Tests
         public MyApiError() { }
         public MyApiError(string message) : base(message) { }
         public MyApiError(string message, Exception inner) : base(message, inner) { }
+    }
+
+    namespace Constants
+    {
+
+        public enum EnumValue
+        {
+            Undefined = 0,
+
+            [EnumMember(Value = "allowed_enum")]
+            AllowedEnum,
+
+        };
     }
 
 }

--- a/Recurly.Tests/JsonSerializerTest.cs
+++ b/Recurly.Tests/JsonSerializerTest.cs
@@ -77,6 +77,24 @@ namespace Recurly.Tests
         }
 
         [Fact]
+        public void DeserializeWithDefinedEnumValue()
+        {
+            var json = "{\"my_string\":\"benjamin\",\"enum_value\":\"allowed_enum\"}";
+            var resource = _jsonSerializer.Deserialize<MyResource>(MockResourceResponse(json));
+            // It should ignore the the unrecognized new field but still parse other properties
+            Assert.Equal(Recurly.Tests.Constants.EnumValue.AllowedEnum, resource.EnumValue);
+        }
+
+        [Fact]
+        public void DeserializeWithUndefinedEnumValue()
+        {
+            var json = "{\"my_string\":\"benjamin\",\"enum_value\":\"undefined_enum\"}";
+            var resource = _jsonSerializer.Deserialize<MyResource>(MockResourceResponse(json));
+            // It should ignore the the unrecognized new field but still parse other properties
+            Assert.Equal(Recurly.Tests.Constants.EnumValue.Undefined, resource.EnumValue);
+        }
+
+        [Fact]
         public void Serialize()
         {
             // make sure it can serialize all primitive types and convert b/w snake and camel case
@@ -91,10 +109,11 @@ namespace Recurly.Tests
                 {
                     new MySubResource() { MyString = "subresource1" },
                     new MySubResource() { MyString = "subresource2" },
-                }
+                },
+                EnumValue = Recurly.Tests.Constants.EnumValue.AllowedEnum
             };
             var jsonStr = _jsonSerializer.Serialize(resource);
-            var json = "{\"my_string\":\"benjamin\",\"my_decimal\":3.14,\"my_int\":3,\"my_sub_resource\":{\"my_string\":\"subresource\"},\"my_array_string\":[\"a\",\"b\"],\"my_array_sub_resource\":[{\"my_string\":\"subresource1\"},{\"my_string\":\"subresource2\"}]}";
+            var json = "{\"my_string\":\"benjamin\",\"my_decimal\":3.14,\"my_int\":3,\"my_sub_resource\":{\"my_string\":\"subresource\"},\"my_array_string\":[\"a\",\"b\"],\"my_array_sub_resource\":[{\"my_string\":\"subresource1\"},{\"my_string\":\"subresource2\"}],\"enum_value\":\"allowed_enum\"}";
             Assert.Equal(jsonStr, json);
         }
         private RestSharp.IRestResponse MockResourceResponse(string json)

--- a/Recurly/Errors/ApiErrors.cs
+++ b/Recurly/Errors/ApiErrors.cs
@@ -5,8 +5,8 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
-using System.Runtime.Serialization;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
 
 namespace Recurly.Errors
 {

--- a/Recurly/RecurlyStringEnumConverter.cs
+++ b/Recurly/RecurlyStringEnumConverter.cs
@@ -18,6 +18,8 @@ namespace Recurly
             }
             catch
             {
+                if (objectType.GetGenericTypeDefinition() == typeof(Nullable<>))
+                    objectType = Nullable.GetUnderlyingType(objectType);
                 return Enum.Parse(objectType, "Undefined");
             }
         }


### PR DESCRIPTION
This is an update for the `4.x` version of the client.

Unknown enum deserialization was failing when an enum value was Nullable. This fix finds the underlying type that the Nullable is wrapping where applicable.