### PR TITLE
New endpoint to verify an account's billing information

### DIFF
--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -250,6 +250,28 @@ namespace Recurly
                 ReadXml);
         }
 
+        /// <summary>
+        /// Verify billing info gateway
+        /// </summary>
+        /// <param name="gatewayCode"></param>
+        public void Verify(string gatewayCode = null)
+        {
+          var verify = new VerifyGateway(gatewayCode);
+          if (gatewayCode.IsNullOrEmpty())
+          {
+              Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
+                  BillingInfoUrl(AccountCode) + "/verify",
+                  verify.ReadXml
+              );
+          } else {
+              Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
+                  BillingInfoUrl(AccountCode) + "/verify",
+                  verify.WriteXml,
+                  verify.ReadXml
+              );
+          };
+        }
+
         private static string BillingInfoUrl(string accountCode)
         {
             return UrlPrefix + Uri.EscapeDataString(accountCode) + UrlPostfix;

--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -256,20 +256,12 @@ namespace Recurly
         /// <param name="gatewayCode"></param>
         public void Verify(string gatewayCode = null)
         {
-          var verify = new VerifyGateway(gatewayCode);
-          if (gatewayCode.IsNullOrEmpty())
-          {
-              Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
-                  BillingInfoUrl(AccountCode) + "/verify",
-                  verify.ReadXml
-              );
-          } else {
-              Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
-                  BillingInfoUrl(AccountCode) + "/verify",
-                  verify.WriteXml,
-                  verify.ReadXml
-              );
-          };
+          var verify = new VerifyBillingInfo(gatewayCode);
+          Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
+              BillingInfoUrl(AccountCode) + "/verify",
+              verify.WriteXml,
+              verify.ReadXml
+          );
         }
 
         private static string BillingInfoUrl(string accountCode)

--- a/Library/Recurly.csproj
+++ b/Library/Recurly.csproj
@@ -140,6 +140,7 @@
     <Compile Include="ValidationException.cs" />
     <Compile Include="Extensions\XmlWriterExtensions.cs" />
     <Compile Include="Tier.cs" />
+    <Compile Include="VerifyGateway.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/Library/Recurly.csproj
+++ b/Library/Recurly.csproj
@@ -140,7 +140,7 @@
     <Compile Include="ValidationException.cs" />
     <Compile Include="Extensions\XmlWriterExtensions.cs" />
     <Compile Include="Tier.cs" />
-    <Compile Include="VerifyGateway.cs" />
+    <Compile Include="VerifyBillingInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/Library/VerifyBillingInfo.cs
+++ b/Library/VerifyBillingInfo.cs
@@ -3,11 +3,11 @@ using System.Xml;
 
 namespace Recurly
 {
-    class VerifyGateway : RecurlyEntity
+    class VerifyBillingInfo : RecurlyEntity
     {
         public string GatewayCode { get; set; }
 
-        internal VerifyGateway(string gateway_code)
+        internal VerifyBillingInfo(string gateway_code)
         {
             GatewayCode = gateway_code;
         }
@@ -29,9 +29,9 @@ namespace Recurly
         internal override void WriteXml(XmlTextWriter writer)
         {
             writer.WriteStartElement("verify");
-
-            writer.WriteElementString("gateway_code", GatewayCode);
-
+            if (!GatewayCode.IsNullOrEmpty()){
+                writer.WriteElementString("gateway_code", GatewayCode);
+            };
             writer.WriteEndElement(); 
         }
     }

--- a/Library/VerifyGateway.cs
+++ b/Library/VerifyGateway.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Xml;
+
+namespace Recurly
+{
+    class VerifyGateway : RecurlyEntity
+    {
+        public string GatewayCode { get; set; }
+
+        internal VerifyGateway(string gateway_code)
+        {
+            GatewayCode = gateway_code;
+        }
+
+        internal override void ReadXml(XmlTextReader reader)
+            {
+            while (reader.Read())
+            {
+              if (reader.Name == "verify" && reader.NodeType == XmlNodeType.EndElement)
+                  break;
+
+              if (reader.NodeType != XmlNodeType.Element) continue;
+
+              if (reader.Name == "gateway_code")
+                    GatewayCode = reader.ReadElementContentAsString();
+            }
+        }
+
+        internal override void WriteXml(XmlTextWriter writer)
+        {
+            writer.WriteStartElement("verify");
+
+            writer.WriteElementString("gateway_code", GatewayCode);
+
+            writer.WriteEndElement(); 
+        }
+    }
+}

--- a/Test/BillingInfoTest.cs
+++ b/Test/BillingInfoTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using FluentAssertions;
 using Xunit;
 using Xunit.Extensions;
@@ -161,6 +162,20 @@ namespace Recurly.Test
                 exception.Errors[0].Symbol.Should().Be("card_type_not_accepted");
             }
             threw.Should().Be(true);
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void VerifyBillingInfo()
+        {
+          var accountCode = GetUniqueAccountCode();
+          var info = NewBillingInfo(accountCode);
+          var account = new Account(accountCode, info);
+          account.Create();
+
+          info.Verify();
+          var transaction = Transactions.List().First();
+          Assert.Equal(transaction.Action, Recurly.Transaction.TransactionType.Verify);
+          Assert.Equal(transaction.Origin, "api_verify_card");
         }
 
         [RecurlyFact(TestEnvironment.Type.Integration)]


### PR DESCRIPTION
If the account has billing information for anything other than a credit card, this will return 422, with an appropriate error message. If successful, this will return 200, with the transaction's data.
`gateway_code` (optional) is the code for the gateway to use for the verification. If unspecified, a gateway will be selected using the normal rules.

Example
```c#
// verify without specifying gateway code to use 
billingInfo.Verify()
// verify with a specific gateway code
billingInfo.Verify("gateway-code")
```