### PR TITLE
Release 1.17.8

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,10 @@
 Unreleased
 ===============
 
+1.17.8 (stable) / 2020-09-17
+===============
+- New endpoint to verify an account's billing information [PR](https://github.com/recurly/recurly-client-dotnet/pull/577)
+
 1.17.7 (stable) / 2020-08-20
 ===============
 This brings us up to API version 2.29. There are no breaking changes.

--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -250,6 +250,20 @@ namespace Recurly
                 ReadXml);
         }
 
+        /// <summary>
+        /// Verify billing info gateway
+        /// </summary>
+        /// <param name="gatewayCode"></param>
+        public void Verify(string gatewayCode = null)
+        {
+          var verify = new VerifyBillingInfo(gatewayCode);
+          Client.Instance.PerformRequest(Client.HttpRequestMethod.Post,
+              BillingInfoUrl(AccountCode) + "/verify",
+              verify.WriteXml,
+              verify.ReadXml
+          );
+        }
+
         private static string BillingInfoUrl(string accountCode)
         {
             return UrlPrefix + Uri.EscapeDataString(accountCode) + UrlPostfix;

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.17.7.0")]
-[assembly: AssemblyFileVersion("1.17.7.0")]
+[assembly: AssemblyVersion("1.17.8.0")]
+[assembly: AssemblyFileVersion("1.17.8.0")]

--- a/Library/Recurly.csproj
+++ b/Library/Recurly.csproj
@@ -140,6 +140,7 @@
     <Compile Include="ValidationException.cs" />
     <Compile Include="Extensions\XmlWriterExtensions.cs" />
     <Compile Include="Tier.cs" />
+    <Compile Include="VerifyBillingInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/Library/VerifyBillingInfo.cs
+++ b/Library/VerifyBillingInfo.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Xml;
+
+namespace Recurly
+{
+    class VerifyBillingInfo : RecurlyEntity
+    {
+        public string GatewayCode { get; set; }
+
+        internal VerifyBillingInfo(string gateway_code)
+        {
+            GatewayCode = gateway_code;
+        }
+
+        internal override void ReadXml(XmlTextReader reader)
+            {
+            while (reader.Read())
+            {
+              if (reader.Name == "verify" && reader.NodeType == XmlNodeType.EndElement)
+                  break;
+
+              if (reader.NodeType != XmlNodeType.Element) continue;
+
+              if (reader.Name == "gateway_code")
+                    GatewayCode = reader.ReadElementContentAsString();
+            }
+        }
+
+        internal override void WriteXml(XmlTextWriter writer)
+        {
+            writer.WriteStartElement("verify");
+            if (!GatewayCode.IsNullOrEmpty()){
+                writer.WriteElementString("gateway_code", GatewayCode);
+            };
+            writer.WriteEndElement(); 
+        }
+    }
+}

--- a/Test/BillingInfoTest.cs
+++ b/Test/BillingInfoTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using FluentAssertions;
 using Xunit;
 using Xunit.Extensions;
@@ -161,6 +162,20 @@ namespace Recurly.Test
                 exception.Errors[0].Symbol.Should().Be("card_type_not_accepted");
             }
             threw.Should().Be(true);
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void VerifyBillingInfo()
+        {
+          var accountCode = GetUniqueAccountCode();
+          var info = NewBillingInfo(accountCode);
+          var account = new Account(accountCode, info);
+          account.Create();
+
+          info.Verify();
+          var transaction = Transactions.List().First();
+          Assert.Equal(transaction.Action, Recurly.Transaction.TransactionType.Verify);
+          Assert.Equal(transaction.Origin, "api_verify_card");
         }
 
         [RecurlyFact(TestEnvironment.Type.Integration)]

--- a/dist/recurly.nuspec
+++ b/dist/recurly.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>recurly-api-client</id>
-    <version>1.17.7</version>
+    <version>1.17.8</version>
     <authors>recurly</authors>
     <owners>recurly</owners>
     <licenseUrl>https://github.com/recurly/recurly-client-net/blob/master/LICENSE.txt</licenseUrl>


### PR DESCRIPTION
This PR merges new features into the v2 branch for release and bumps the dotnet client library version to 1.17.8.

------
- New endpoint to verify an account's billing information https://github.com/recurly/recurly-client-dotnet/pull/577
