### PR TITLE
Updating client to be compliant with RFC 2616: case-insensitive headers

### DIFF
--- a/Recurly.Tests/PagerTest.cs
+++ b/Recurly.Tests/PagerTest.cs
@@ -134,9 +134,9 @@ namespace Recurly.Tests
                 { "limit", 200 },
                 { "a", 1 },
             };
-            var clientMock = GetPagerCountClient();
+            var client = MockClient.Build(PagerCountResponse());
 
-            var pager = Pager<MyResource>.Build("/resources", queryParams, null, clientMock);
+            var pager = Pager<MyResource>.Build("/resources", queryParams, null, client);
 
             var count = pager.Count();
             Assert.Equal(42, count);
@@ -251,34 +251,15 @@ namespace Recurly.Tests
             return response;
         }
 
-        private Mock<IRestResponse> PagerCountResponse()
+        private Mock<IRestResponse<EmptyResource>> PagerCountResponse()
         {
-            var response = new Mock<IRestResponse>();
+            var response = new Mock<IRestResponse<EmptyResource>>();
             response.Setup(_ => _.StatusCode).Returns(System.Net.HttpStatusCode.OK);
             response.Setup(_ => _.Headers).Returns(new List<Parameter> {
                 new RestSharp.Parameter("Recurly-Total-Records", "42", ParameterType.HttpHeader),
             });
 
             return response;
-        }
-
-        private Recurly.Client GetPagerCountClient()
-        {
-            var pageResponse = new Mock<IRestResponse>();
-            pageResponse.Setup(_ => _.StatusCode).Returns(System.Net.HttpStatusCode.OK);
-            pageResponse.Setup(_ => _.Headers).Returns(new List<Parameter> {
-                new RestSharp.Parameter("Recurly-Total-Records", "42", ParameterType.HttpHeader),
-            });
-            var mockIRestClient = new Mock<IRestClient>();
-
-            mockIRestClient
-                .Setup(x => x.Execute(It.Is<RestRequest>(r => r.Method == Method.HEAD)))
-                .Returns(pageResponse.Object);
-
-            return new Recurly.Client("myapikey")
-            {
-                RestClient = mockIRestClient.Object
-            };
         }
     }
 }

--- a/Recurly/BaseClient.cs
+++ b/Recurly/BaseClient.cs
@@ -72,7 +72,7 @@ namespace Recurly
             });
         }
 
-        public T MakeRequest<T>(Method method, string url, Request body = null, Dictionary<string, object> queryParams = null, RequestOptions options = null) where T : Resource
+        public T MakeRequest<T>(Method method, string url, Request body = null, Dictionary<string, object> queryParams = null, RequestOptions options = null) where T : Resource, new()
         {
             Debug.WriteLine($"Calling {url}");
             var httpRequest = new Http.Request()
@@ -97,6 +97,13 @@ namespace Recurly
             }
 
             this.HandleResponse(restResponse);
+
+            if (typeof(T).Equals(typeof(EmptyResource)))
+            {
+                var empty = new T();
+                empty.SetResponse(httpResponse);
+                return empty;
+            }
 
             if (restResponse.Data is Resource)
                 restResponse.Data.SetResponse(httpResponse);

--- a/Recurly/Http.cs
+++ b/Recurly/Http.cs
@@ -24,17 +24,17 @@ namespace Recurly.Http
 
         public IList<Header> Headers { get; set; }
 
-        public string RequestId { get { return GetHeader("X-Request-Id"); } }
+        public string RequestId { get { return GetHeader("x-request-id"); } }
 
-        public int? RateLimit { get { return GetIntHeader("X-RateLimit-Limit"); } }
+        public int? RateLimit { get { return GetIntHeader("x-ratelimit-limit"); } }
 
-        public int? RateLimitRemaining { get { return GetIntHeader("X-RateLimit-Remaining"); } }
+        public int? RateLimitRemaining { get { return GetIntHeader("x-ratelimit-remaining"); } }
 
-        public int? RateLimitReset { get { return GetIntHeader("X-RateLimit-Reset"); } }
+        public int? RateLimitReset { get { return GetIntHeader("x-ratelimit-reset"); } }
 
-        public string ContentType { get { return GetHeader("Content-Type"); } }
+        public string ContentType { get { return GetHeader("content-type"); } }
 
-        public int? RecordCount { get { return GetIntHeader("Recurly-Total-Records"); } }
+        public int? RecordCount { get { return GetIntHeader("recurly-total-records"); } }
 
         public Response() { }
 
@@ -55,10 +55,10 @@ namespace Recurly.Http
             };
         }
 
-        private string GetHeader(string name)
+        public string GetHeader(string name)
         {
             foreach (var header in Headers)
-                if (header.Name == name)
+                if (header.Name == name.ToLower())
                     return header.Value;
             return null;
         }
@@ -87,7 +87,7 @@ namespace Recurly.Http
 
         public Header(string name, string value)
         {
-            Name = name;
+            Name = name.ToLower();
             Value = value;
         }
     }

--- a/Recurly/Pager.cs
+++ b/Recurly/Pager.cs
@@ -59,7 +59,13 @@ namespace Recurly
 
         public int Count()
         {
-            return RecurlyClient.GetResourceCount(Url, QueryParams);
+            var empty = RecurlyClient.MakeRequest<EmptyResource>(Method.HEAD, Url, null, QueryParams, Options);
+
+            var meta = empty.GetResponse();
+            if (meta.RecordCount is null)
+                throw new RecurlyError($"Invalid value for recurly-total-records header: {meta.GetHeader("recurly-total-records")}");
+
+            return (int)meta.RecordCount;
         }
 
         public Pager<T> FetchNextPage()


### PR DESCRIPTION
According to section 4.2 of [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt):

> Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.

This update will make the client treat headers in a case-insensitive manner.

The `Recurly.Http.Response` class has also been updated to expose the `GetHeader` method.