### PR TITLE
Adding OptionalParams and per-operation implementations

### DIFF
--- a/Recurly.Tests/Fixtures.cs
+++ b/Recurly.Tests/Fixtures.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
+using Recurly;
 
 namespace Recurly.Tests
 {
@@ -51,6 +52,21 @@ namespace Recurly.Tests
         public MyApiError() { }
         public MyApiError(string message) : base(message) { }
         public MyApiError(string message, Exception inner) : base(message, inner) { }
+    }
+
+    public class ListResourcesParams : OptionalParams
+    {
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("allowed")]
+        public Constants.EnumValue? Allowed { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
     }
 
     namespace Constants

--- a/Recurly.Tests/OptionalParamsTest.cs
+++ b/Recurly.Tests/OptionalParamsTest.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using Moq;
+using Recurly;
+using Xunit;
+
+namespace Recurly.Tests
+{
+    public class OptionalParamsTest
+    {
+        public OptionalParamsTest() { }
+
+        [Fact]
+        public void CanDoSomething()
+        {
+            var optionalParams = new ListResourcesParams()
+            {
+                Limit = 200
+            };
+            var paramsDict = optionalParams.ToDictionary();
+
+            Assert.IsType<Dictionary<string, object>>(paramsDict);
+            var expectedKeys = new[] { "ids", "limit", "allowed", "begin_time" };
+            foreach (var key in expectedKeys)
+            {
+                Assert.Contains(key, paramsDict.Keys);
+            }
+            Assert.Equal(200, paramsDict["limit"]);
+        }
+    }
+}

--- a/Recurly/Client.cs
+++ b/Recurly/Client.cs
@@ -33,10 +33,10 @@ namespace Recurly
         /// <returns>
         /// A list of sites.
         /// </returns>
-        public Pager<Site> ListSites(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, Constants.ActiveState? state = null, RequestOptions options = null)
+        public Pager<Site> ListSites(ListSitesParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "state", state } };
+            var queryParams = (optionalParams ?? new ListSitesParams()).ToDictionary();
             var url = this.InterpolatePath("/sites", urlParams);
             return Pager<Site>.Build(url, queryParams, options, this);
         }
@@ -94,10 +94,10 @@ namespace Recurly
         /// <returns>
         /// A list of the site's accounts.
         /// </returns>
-        public Pager<Account> ListAccounts(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, string email = null, bool? subscriber = null, Constants.True? pastDue = null, RequestOptions options = null)
+        public Pager<Account> ListAccounts(ListAccountsParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime }, { "email", email }, { "subscriber", subscriber }, { "past_due", pastDue } };
+            var queryParams = (optionalParams ?? new ListAccountsParams()).ToDictionary();
             var url = this.InterpolatePath("/accounts", urlParams);
             return Pager<Account>.Build(url, queryParams, options, this);
         }
@@ -531,10 +531,10 @@ namespace Recurly
         /// <returns>
         /// A list of the the coupon redemptions on an account.
         /// </returns>
-        public Pager<CouponRedemption> ListAccountCouponRedemptions(string accountId, string ids = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, RequestOptions options = null)
+        public Pager<CouponRedemption> ListAccountCouponRedemptions(string accountId, ListAccountCouponRedemptionsParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "account_id", accountId } };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime } };
+            var queryParams = (optionalParams ?? new ListAccountCouponRedemptionsParams()).ToDictionary();
             var url = this.InterpolatePath("/accounts/{account_id}/coupon_redemptions", urlParams);
             return Pager<CouponRedemption>.Build(url, queryParams, options, this);
         }
@@ -544,36 +544,20 @@ namespace Recurly
 
 
         /// <summary>
-        /// Show the coupon redemption that is active on an account <see href="https://developers.recurly.com/api/v2020-01-01#operation/get_active_coupon_redemption">get_active_coupon_redemption api documentation</see>
+        /// Show the coupon redemptions that are active on an account <see href="https://developers.recurly.com/api/v2020-01-01#operation/list_active_coupon_redemptions">list_active_coupon_redemptions api documentation</see>
         /// </summary>
         /// <param name="accountId">Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.</param>
         /// <returns>
-        /// An active coupon redemption on an account.
+        /// Active coupon redemptions on an account.
         /// </returns>
-        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        public CouponRedemption GetActiveCouponRedemption(string accountId, RequestOptions options = null)
+        public Pager<CouponRedemption> ListActiveCouponRedemptions(string accountId, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "account_id", accountId } };
             var url = this.InterpolatePath("/accounts/{account_id}/coupon_redemptions/active", urlParams);
-            return MakeRequest<CouponRedemption>(Method.GET, url, null, null, options);
+            return Pager<CouponRedemption>.Build(url, null, options, this);
         }
 
 
-
-        /// <summary>
-        /// Show the coupon redemption that is active on an account <see href="https://developers.recurly.com/api/v2020-01-01#operation/get_active_coupon_redemption">get_active_coupon_redemption api documentation</see>
-        /// </summary>
-        /// <param name="accountId">Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.</param>
-        /// <returns>
-        /// An active coupon redemption on an account.
-        /// </returns>
-        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        public Task<CouponRedemption> GetActiveCouponRedemptionAsync(string accountId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)
-        {
-            var urlParams = new Dictionary<string, object> { { "account_id", accountId } };
-            var url = this.InterpolatePath("/accounts/{account_id}/coupon_redemptions/active", urlParams);
-            return MakeRequestAsync<CouponRedemption>(Method.GET, url, null, null, options, cancellationToken);
-        }
 
 
 
@@ -659,10 +643,10 @@ namespace Recurly
         /// <returns>
         /// A list of the account's credit payments.
         /// </returns>
-        public Pager<CreditPayment> ListAccountCreditPayments(string accountId, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, RequestOptions options = null)
+        public Pager<CreditPayment> ListAccountCreditPayments(string accountId, ListAccountCreditPaymentsParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "account_id", accountId } };
-            var queryParams = new Dictionary<string, object> { { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime } };
+            var queryParams = (optionalParams ?? new ListAccountCreditPaymentsParams()).ToDictionary();
             var url = this.InterpolatePath("/accounts/{account_id}/credit_payments", urlParams);
             return Pager<CreditPayment>.Build(url, queryParams, options, this);
         }
@@ -685,10 +669,10 @@ namespace Recurly
         /// <returns>
         /// A list of the account's invoices.
         /// </returns>
-        public Pager<Invoice> ListAccountInvoices(string accountId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.FilterInvoiceType? type = null, RequestOptions options = null)
+        public Pager<Invoice> ListAccountInvoices(string accountId, ListAccountInvoicesParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "account_id", accountId } };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime }, { "type", type } };
+            var queryParams = (optionalParams ?? new ListAccountInvoicesParams()).ToDictionary();
             var url = this.InterpolatePath("/accounts/{account_id}/invoices", urlParams);
             return Pager<Invoice>.Build(url, queryParams, options, this);
         }
@@ -785,10 +769,10 @@ namespace Recurly
         /// <returns>
         /// A list of the account's line items.
         /// </returns>
-        public Pager<LineItem> ListAccountLineItems(string accountId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.True? original = null, Constants.LineItemState? state = null, Constants.LintItemType? type = null, RequestOptions options = null)
+        public Pager<LineItem> ListAccountLineItems(string accountId, ListAccountLineItemsParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "account_id", accountId } };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime }, { "original", original }, { "state", state }, { "type", type } };
+            var queryParams = (optionalParams ?? new ListAccountLineItemsParams()).ToDictionary();
             var url = this.InterpolatePath("/accounts/{account_id}/line_items", urlParams);
             return Pager<LineItem>.Build(url, queryParams, options, this);
         }
@@ -841,10 +825,10 @@ namespace Recurly
         /// <returns>
         /// A list of an account's notes.
         /// </returns>
-        public Pager<AccountNote> ListAccountNotes(string accountId, string ids = null, RequestOptions options = null)
+        public Pager<AccountNote> ListAccountNotes(string accountId, ListAccountNotesParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "account_id", accountId } };
-            var queryParams = new Dictionary<string, object> { { "ids", ids } };
+            var queryParams = (optionalParams ?? new ListAccountNotesParams()).ToDictionary();
             var url = this.InterpolatePath("/accounts/{account_id}/notes", urlParams);
             return Pager<AccountNote>.Build(url, queryParams, options, this);
         }
@@ -902,10 +886,10 @@ namespace Recurly
         /// <returns>
         /// A list of an account's shipping addresses.
         /// </returns>
-        public Pager<ShippingAddress> ListShippingAddresses(string accountId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, RequestOptions options = null)
+        public Pager<ShippingAddress> ListShippingAddresses(string accountId, ListShippingAddressesParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "account_id", accountId } };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime } };
+            var queryParams = (optionalParams ?? new ListShippingAddressesParams()).ToDictionary();
             var url = this.InterpolatePath("/accounts/{account_id}/shipping_addresses", urlParams);
             return Pager<ShippingAddress>.Build(url, queryParams, options, this);
         }
@@ -1074,10 +1058,10 @@ namespace Recurly
         /// <returns>
         /// A list of the account's subscriptions.
         /// </returns>
-        public Pager<Subscription> ListAccountSubscriptions(string accountId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.FilterSubscriptionState? state = null, RequestOptions options = null)
+        public Pager<Subscription> ListAccountSubscriptions(string accountId, ListAccountSubscriptionsParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "account_id", accountId } };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime }, { "state", state } };
+            var queryParams = (optionalParams ?? new ListAccountSubscriptionsParams()).ToDictionary();
             var url = this.InterpolatePath("/accounts/{account_id}/subscriptions", urlParams);
             return Pager<Subscription>.Build(url, queryParams, options, this);
         }
@@ -1101,10 +1085,10 @@ namespace Recurly
         /// <returns>
         /// A list of the account's transactions.
         /// </returns>
-        public Pager<Transaction> ListAccountTransactions(string accountId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.FilterTransactionType? type = null, Constants.True? success = null, RequestOptions options = null)
+        public Pager<Transaction> ListAccountTransactions(string accountId, ListAccountTransactionsParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "account_id", accountId } };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime }, { "type", type }, { "success", success } };
+            var queryParams = (optionalParams ?? new ListAccountTransactionsParams()).ToDictionary();
             var url = this.InterpolatePath("/accounts/{account_id}/transactions", urlParams);
             return Pager<Transaction>.Build(url, queryParams, options, this);
         }
@@ -1129,10 +1113,10 @@ namespace Recurly
         /// <returns>
         /// A list of an account's child accounts.
         /// </returns>
-        public Pager<Account> ListChildAccounts(string accountId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, string email = null, bool? subscriber = null, Constants.True? pastDue = null, RequestOptions options = null)
+        public Pager<Account> ListChildAccounts(string accountId, ListChildAccountsParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "account_id", accountId } };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime }, { "email", email }, { "subscriber", subscriber }, { "past_due", pastDue } };
+            var queryParams = (optionalParams ?? new ListChildAccountsParams()).ToDictionary();
             var url = this.InterpolatePath("/accounts/{account_id}/accounts", urlParams);
             return Pager<Account>.Build(url, queryParams, options, this);
         }
@@ -1153,10 +1137,10 @@ namespace Recurly
         /// <returns>
         /// A list of the site's account acquisition data.
         /// </returns>
-        public Pager<AccountAcquisition> ListAccountAcquisition(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, RequestOptions options = null)
+        public Pager<AccountAcquisition> ListAccountAcquisition(ListAccountAcquisitionParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime } };
+            var queryParams = (optionalParams ?? new ListAccountAcquisitionParams()).ToDictionary();
             var url = this.InterpolatePath("/acquisitions", urlParams);
             return Pager<AccountAcquisition>.Build(url, queryParams, options, this);
         }
@@ -1177,10 +1161,10 @@ namespace Recurly
         /// <returns>
         /// A list of the site's coupons.
         /// </returns>
-        public Pager<Coupon> ListCoupons(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, RequestOptions options = null)
+        public Pager<Coupon> ListCoupons(ListCouponsParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime } };
+            var queryParams = (optionalParams ?? new ListCouponsParams()).ToDictionary();
             var url = this.InterpolatePath("/coupons", urlParams);
             return Pager<Coupon>.Build(url, queryParams, options, this);
         }
@@ -1340,10 +1324,10 @@ namespace Recurly
         /// <returns>
         /// A list of unique coupon codes that were generated
         /// </returns>
-        public Pager<UniqueCouponCode> ListUniqueCouponCodes(string couponId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, RequestOptions options = null)
+        public Pager<UniqueCouponCode> ListUniqueCouponCodes(string couponId, ListUniqueCouponCodesParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "coupon_id", couponId } };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime } };
+            var queryParams = (optionalParams ?? new ListUniqueCouponCodesParams()).ToDictionary();
             var url = this.InterpolatePath("/coupons/{coupon_id}/unique_coupon_codes", urlParams);
             return Pager<UniqueCouponCode>.Build(url, queryParams, options, this);
         }
@@ -1363,10 +1347,10 @@ namespace Recurly
         /// <returns>
         /// A list of the site's credit payments.
         /// </returns>
-        public Pager<CreditPayment> ListCreditPayments(int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, RequestOptions options = null)
+        public Pager<CreditPayment> ListCreditPayments(ListCreditPaymentsParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { };
-            var queryParams = new Dictionary<string, object> { { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime } };
+            var queryParams = (optionalParams ?? new ListCreditPaymentsParams()).ToDictionary();
             var url = this.InterpolatePath("/credit_payments", urlParams);
             return Pager<CreditPayment>.Build(url, queryParams, options, this);
         }
@@ -1422,10 +1406,10 @@ namespace Recurly
         /// <returns>
         /// A list of the site's custom field definitions.
         /// </returns>
-        public Pager<CustomFieldDefinition> ListCustomFieldDefinitions(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.RelatedType? relatedType = null, RequestOptions options = null)
+        public Pager<CustomFieldDefinition> ListCustomFieldDefinitions(ListCustomFieldDefinitionsParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime }, { "related_type", relatedType } };
+            var queryParams = (optionalParams ?? new ListCustomFieldDefinitionsParams()).ToDictionary();
             var url = this.InterpolatePath("/custom_field_definitions", urlParams);
             return Pager<CustomFieldDefinition>.Build(url, queryParams, options, this);
         }
@@ -1481,10 +1465,10 @@ namespace Recurly
         /// <returns>
         /// A list of the site's items.
         /// </returns>
-        public Pager<Item> ListItems(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.ActiveState? state = null, RequestOptions options = null)
+        public Pager<Item> ListItems(ListItemsParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime }, { "state", state } };
+            var queryParams = (optionalParams ?? new ListItemsParams()).ToDictionary();
             var url = this.InterpolatePath("/items", urlParams);
             return Pager<Item>.Build(url, queryParams, options, this);
         }
@@ -1678,10 +1662,10 @@ namespace Recurly
         /// <returns>
         /// A list of the site's measured units.
         /// </returns>
-        public Pager<MeasuredUnit> ListMeasuredUnit(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.ActiveState? state = null, RequestOptions options = null)
+        public Pager<MeasuredUnit> ListMeasuredUnit(ListMeasuredUnitParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime }, { "state", state } };
+            var queryParams = (optionalParams ?? new ListMeasuredUnitParams()).ToDictionary();
             var url = this.InterpolatePath("/measured_units", urlParams);
             return Pager<MeasuredUnit>.Build(url, queryParams, options, this);
         }
@@ -1841,10 +1825,10 @@ namespace Recurly
         /// <returns>
         /// A list of the site's invoices.
         /// </returns>
-        public Pager<Invoice> ListInvoices(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.FilterInvoiceType? type = null, RequestOptions options = null)
+        public Pager<Invoice> ListInvoices(ListInvoicesParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime }, { "type", type } };
+            var queryParams = (optionalParams ?? new ListInvoicesParams()).ToDictionary();
             var url = this.InterpolatePath("/invoices", urlParams);
             return Pager<Invoice>.Build(url, queryParams, options, this);
         }
@@ -2179,10 +2163,10 @@ namespace Recurly
         /// <returns>
         /// A list of the invoice's line items.
         /// </returns>
-        public Pager<LineItem> ListInvoiceLineItems(string invoiceId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.True? original = null, Constants.LineItemState? state = null, Constants.LintItemType? type = null, RequestOptions options = null)
+        public Pager<LineItem> ListInvoiceLineItems(string invoiceId, ListInvoiceLineItemsParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "invoice_id", invoiceId } };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime }, { "original", original }, { "state", state }, { "type", type } };
+            var queryParams = (optionalParams ?? new ListInvoiceLineItemsParams()).ToDictionary();
             var url = this.InterpolatePath("/invoices/{invoice_id}/line_items", urlParams);
             return Pager<LineItem>.Build(url, queryParams, options, this);
         }
@@ -2202,10 +2186,10 @@ namespace Recurly
         /// <returns>
         /// A list of the the coupon redemptions associated with the invoice.
         /// </returns>
-        public Pager<CouponRedemption> ListInvoiceCouponRedemptions(string invoiceId, string ids = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, RequestOptions options = null)
+        public Pager<CouponRedemption> ListInvoiceCouponRedemptions(string invoiceId, ListInvoiceCouponRedemptionsParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "invoice_id", invoiceId } };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime } };
+            var queryParams = (optionalParams ?? new ListInvoiceCouponRedemptionsParams()).ToDictionary();
             var url = this.InterpolatePath("/invoices/{invoice_id}/coupon_redemptions", urlParams);
             return Pager<CouponRedemption>.Build(url, queryParams, options, this);
         }
@@ -2283,10 +2267,10 @@ namespace Recurly
         /// <returns>
         /// A list of the site's line items.
         /// </returns>
-        public Pager<LineItem> ListLineItems(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.True? original = null, Constants.LineItemState? state = null, Constants.LintItemType? type = null, RequestOptions options = null)
+        public Pager<LineItem> ListLineItems(ListLineItemsParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime }, { "original", original }, { "state", state }, { "type", type } };
+            var queryParams = (optionalParams ?? new ListLineItemsParams()).ToDictionary();
             var url = this.InterpolatePath("/line_items", urlParams);
             return Pager<LineItem>.Build(url, queryParams, options, this);
         }
@@ -2376,10 +2360,10 @@ namespace Recurly
         /// <returns>
         /// A list of plans.
         /// </returns>
-        public Pager<Plan> ListPlans(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.ActiveState? state = null, RequestOptions options = null)
+        public Pager<Plan> ListPlans(ListPlansParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime }, { "state", state } };
+            var queryParams = (optionalParams ?? new ListPlansParams()).ToDictionary();
             var url = this.InterpolatePath("/plans", urlParams);
             return Pager<Plan>.Build(url, queryParams, options, this);
         }
@@ -2540,10 +2524,10 @@ namespace Recurly
         /// <returns>
         /// A list of add-ons.
         /// </returns>
-        public Pager<AddOn> ListPlanAddOns(string planId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.ActiveState? state = null, RequestOptions options = null)
+        public Pager<AddOn> ListPlanAddOns(string planId, ListPlanAddOnsParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "plan_id", planId } };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime }, { "state", state } };
+            var queryParams = (optionalParams ?? new ListPlanAddOnsParams()).ToDictionary();
             var url = this.InterpolatePath("/plans/{plan_id}/add_ons", urlParams);
             return Pager<AddOn>.Build(url, queryParams, options, this);
         }
@@ -2711,10 +2695,10 @@ namespace Recurly
         /// <returns>
         /// A list of add-ons.
         /// </returns>
-        public Pager<AddOn> ListAddOns(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.ActiveState? state = null, RequestOptions options = null)
+        public Pager<AddOn> ListAddOns(ListAddOnsParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime }, { "state", state } };
+            var queryParams = (optionalParams ?? new ListAddOnsParams()).ToDictionary();
             var url = this.InterpolatePath("/add_ons", urlParams);
             return Pager<AddOn>.Build(url, queryParams, options, this);
         }
@@ -2769,10 +2753,10 @@ namespace Recurly
         /// <returns>
         /// A list of the site's shipping methods.
         /// </returns>
-        public Pager<ShippingMethod> ListShippingMethods(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, RequestOptions options = null)
+        public Pager<ShippingMethod> ListShippingMethods(ListShippingMethodsParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime } };
+            var queryParams = (optionalParams ?? new ListShippingMethodsParams()).ToDictionary();
             var url = this.InterpolatePath("/shipping_methods", urlParams);
             return Pager<ShippingMethod>.Build(url, queryParams, options, this);
         }
@@ -2932,10 +2916,10 @@ namespace Recurly
         /// <returns>
         /// A list of the site's subscriptions.
         /// </returns>
-        public Pager<Subscription> ListSubscriptions(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.FilterSubscriptionState? state = null, RequestOptions options = null)
+        public Pager<Subscription> ListSubscriptions(ListSubscriptionsParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime }, { "state", state } };
+            var queryParams = (optionalParams ?? new ListSubscriptionsParams()).ToDictionary();
             var url = this.InterpolatePath("/subscriptions", urlParams);
             return Pager<Subscription>.Build(url, queryParams, options, this);
         }
@@ -3057,10 +3041,10 @@ namespace Recurly
         /// An expired subscription.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        public Subscription TerminateSubscription(string subscriptionId, Constants.RefundType? refund = null, RequestOptions options = null)
+        public Subscription TerminateSubscription(string subscriptionId, TerminateSubscriptionParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "subscription_id", subscriptionId } };
-            var queryParams = new Dictionary<string, object> { { "refund", refund } };
+            var queryParams = (optionalParams ?? new TerminateSubscriptionParams()).ToDictionary();
             var url = this.InterpolatePath("/subscriptions/{subscription_id}", urlParams);
             return MakeRequest<Subscription>(Method.DELETE, url, null, queryParams, options);
         }
@@ -3076,10 +3060,10 @@ namespace Recurly
         /// An expired subscription.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        public Task<Subscription> TerminateSubscriptionAsync(string subscriptionId, Constants.RefundType? refund = null, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)
+        public Task<Subscription> TerminateSubscriptionAsync(string subscriptionId, TerminateSubscriptionParams optionalParams = null, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "subscription_id", subscriptionId } };
-            var queryParams = new Dictionary<string, object> { { "refund", refund } };
+            var queryParams = (optionalParams ?? new TerminateSubscriptionParams()).ToDictionary();
             var url = this.InterpolatePath("/subscriptions/{subscription_id}", urlParams);
             return MakeRequestAsync<Subscription>(Method.DELETE, url, null, queryParams, options, cancellationToken);
         }
@@ -3412,10 +3396,10 @@ namespace Recurly
         /// <returns>
         /// A list of the subscription's invoices.
         /// </returns>
-        public Pager<Invoice> ListSubscriptionInvoices(string subscriptionId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.FilterInvoiceType? type = null, RequestOptions options = null)
+        public Pager<Invoice> ListSubscriptionInvoices(string subscriptionId, ListSubscriptionInvoicesParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "subscription_id", subscriptionId } };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime }, { "type", type } };
+            var queryParams = (optionalParams ?? new ListSubscriptionInvoicesParams()).ToDictionary();
             var url = this.InterpolatePath("/subscriptions/{subscription_id}/invoices", urlParams);
             return Pager<Invoice>.Build(url, queryParams, options, this);
         }
@@ -3440,10 +3424,10 @@ namespace Recurly
         /// <returns>
         /// A list of the subscription's line items.
         /// </returns>
-        public Pager<LineItem> ListSubscriptionLineItems(string subscriptionId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.True? original = null, Constants.LineItemState? state = null, Constants.LintItemType? type = null, RequestOptions options = null)
+        public Pager<LineItem> ListSubscriptionLineItems(string subscriptionId, ListSubscriptionLineItemsParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "subscription_id", subscriptionId } };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime }, { "original", original }, { "state", state }, { "type", type } };
+            var queryParams = (optionalParams ?? new ListSubscriptionLineItemsParams()).ToDictionary();
             var url = this.InterpolatePath("/subscriptions/{subscription_id}/line_items", urlParams);
             return Pager<LineItem>.Build(url, queryParams, options, this);
         }
@@ -3463,10 +3447,10 @@ namespace Recurly
         /// <returns>
         /// A list of the the coupon redemptions on a subscription.
         /// </returns>
-        public Pager<CouponRedemption> ListSubscriptionCouponRedemptions(string subscriptionId, string ids = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, RequestOptions options = null)
+        public Pager<CouponRedemption> ListSubscriptionCouponRedemptions(string subscriptionId, ListSubscriptionCouponRedemptionsParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "subscription_id", subscriptionId } };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime } };
+            var queryParams = (optionalParams ?? new ListSubscriptionCouponRedemptionsParams()).ToDictionary();
             var url = this.InterpolatePath("/subscriptions/{subscription_id}/coupon_redemptions", urlParams);
             return Pager<CouponRedemption>.Build(url, queryParams, options, this);
         }
@@ -3490,10 +3474,10 @@ namespace Recurly
         /// <returns>
         /// A list of the subscription add-on's usage records.
         /// </returns>
-        public Pager<Usage> ListUsage(string subscriptionId, string addOnId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.UsageSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.BillingStatus? billingStatus = null, RequestOptions options = null)
+        public Pager<Usage> ListUsage(string subscriptionId, string addOnId, ListUsageParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { { "subscription_id", subscriptionId }, { "add_on_id", addOnId } };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime }, { "billing_status", billingStatus } };
+            var queryParams = (optionalParams ?? new ListUsageParams()).ToDictionary();
             var url = this.InterpolatePath("/subscriptions/{subscription_id}/add_ons/{add_on_id}/usage", urlParams);
             return Pager<Usage>.Build(url, queryParams, options, this);
         }
@@ -3658,10 +3642,10 @@ namespace Recurly
         /// <returns>
         /// A list of the site's transactions.
         /// </returns>
-        public Pager<Transaction> ListTransactions(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.FilterTransactionType? type = null, Constants.True? success = null, RequestOptions options = null)
+        public Pager<Transaction> ListTransactions(ListTransactionsParams optionalParams = null, RequestOptions options = null)
         {
             var urlParams = new Dictionary<string, object> { };
-            var queryParams = new Dictionary<string, object> { { "ids", ids }, { "limit", limit }, { "order", order }, { "sort", sort }, { "begin_time", beginTime }, { "end_time", endTime }, { "type", type }, { "success", success } };
+            var queryParams = (optionalParams ?? new ListTransactionsParams()).ToDictionary();
             var url = this.InterpolatePath("/transactions", urlParams);
             return Pager<Transaction>.Build(url, queryParams, options, this);
         }
@@ -3870,6 +3854,72 @@ namespace Recurly
             var urlParams = new Dictionary<string, object> { };
             var url = this.InterpolatePath("/purchases/preview", urlParams);
             return MakeRequestAsync<InvoiceCollection>(Method.POST, url, body, null, options, cancellationToken);
+        }
+
+
+
+        /// <summary>
+        /// List the dates that have an available export to download. <see href="https://developers.recurly.com/api/v2020-01-01#operation/get_export_dates">get_export_dates api documentation</see>
+        /// </summary>
+        /// <returns>
+        /// Returns a list of dates.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        public ExportDates GetExportDates(RequestOptions options = null)
+        {
+            var urlParams = new Dictionary<string, object> { };
+            var url = this.InterpolatePath("/export_dates", urlParams);
+            return MakeRequest<ExportDates>(Method.GET, url, null, null, options);
+        }
+
+
+
+        /// <summary>
+        /// List the dates that have an available export to download. <see href="https://developers.recurly.com/api/v2020-01-01#operation/get_export_dates">get_export_dates api documentation</see>
+        /// </summary>
+        /// <returns>
+        /// Returns a list of dates.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        public Task<ExportDates> GetExportDatesAsync(CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)
+        {
+            var urlParams = new Dictionary<string, object> { };
+            var url = this.InterpolatePath("/export_dates", urlParams);
+            return MakeRequestAsync<ExportDates>(Method.GET, url, null, null, options, cancellationToken);
+        }
+
+
+
+        /// <summary>
+        /// List of the export files that are available to download. <see href="https://developers.recurly.com/api/v2020-01-01#operation/get_export_files">get_export_files api documentation</see>
+        /// </summary>
+        /// <param name="exportDate">Date for which to get a list of available automated export files. Date must be in YYYY-MM-DD format.</param>
+        /// <returns>
+        /// Returns a list of export files to download.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        public ExportFiles GetExportFiles(string exportDate, RequestOptions options = null)
+        {
+            var urlParams = new Dictionary<string, object> { { "export_date", exportDate } };
+            var url = this.InterpolatePath("/export_dates/{export_date}/export_files", urlParams);
+            return MakeRequest<ExportFiles>(Method.GET, url, null, null, options);
+        }
+
+
+
+        /// <summary>
+        /// List of the export files that are available to download. <see href="https://developers.recurly.com/api/v2020-01-01#operation/get_export_files">get_export_files api documentation</see>
+        /// </summary>
+        /// <param name="exportDate">Date for which to get a list of available automated export files. Date must be in YYYY-MM-DD format.</param>
+        /// <returns>
+        /// Returns a list of export files to download.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        public Task<ExportFiles> GetExportFilesAsync(string exportDate, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null)
+        {
+            var urlParams = new Dictionary<string, object> { { "export_date", exportDate } };
+            var url = this.InterpolatePath("/export_dates/{export_date}/export_files", urlParams);
+            return MakeRequestAsync<ExportFiles>(Method.GET, url, null, null, options, cancellationToken);
         }
 
 

--- a/Recurly/Constants.cs
+++ b/Recurly/Constants.cs
@@ -639,6 +639,9 @@ namespace Recurly
             [EnumMember(Value = "write_off")]
             WriteOff,
 
+            [EnumMember(Value = "prepayment")]
+            Prepayment,
+
         };
 
         public enum InvoiceState
@@ -828,6 +831,9 @@ namespace Recurly
             [EnumMember(Value = "setup_fee")]
             SetupFee,
 
+            [EnumMember(Value = "prepayment")]
+            Prepayment,
+
         };
 
         public enum FullCreditReasonCode
@@ -869,12 +875,15 @@ namespace Recurly
 
         };
 
-        public enum GiftCodeOrigin
+        public enum LineItemCreateOrigin
         {
             Undefined = 0,
 
             [EnumMember(Value = "external_gift_card")]
             ExternalGiftCard,
+
+            [EnumMember(Value = "prepayment")]
+            Prepayment,
 
         };
 

--- a/Recurly/IClient.cs
+++ b/Recurly/IClient.cs
@@ -27,7 +27,7 @@ namespace Recurly
         /// <returns>
         /// A list of sites.
         /// </returns>
-        Pager<Site> ListSites(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, Constants.ActiveState? state = null, RequestOptions options = null);
+        Pager<Site> ListSites(ListSitesParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace Recurly
         /// <returns>
         /// A list of the site's accounts.
         /// </returns>
-        Pager<Account> ListAccounts(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, string email = null, bool? subscriber = null, Constants.True? pastDue = null, RequestOptions options = null);
+        Pager<Account> ListAccounts(ListAccountsParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -325,28 +325,18 @@ namespace Recurly
         /// <returns>
         /// A list of the the coupon redemptions on an account.
         /// </returns>
-        Pager<CouponRedemption> ListAccountCouponRedemptions(string accountId, string ids = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, RequestOptions options = null);
+        Pager<CouponRedemption> ListAccountCouponRedemptions(string accountId, ListAccountCouponRedemptionsParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
-        /// Show the coupon redemption that is active on an account <see href="https://developers.recurly.com/api/v2020-01-01#operation/get_active_coupon_redemption">get_active_coupon_redemption api documentation</see>
+        /// Show the coupon redemptions that are active on an account <see href="https://developers.recurly.com/api/v2020-01-01#operation/list_active_coupon_redemptions">list_active_coupon_redemptions api documentation</see>
         /// </summary>
         /// <param name="accountId">Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.</param>
         /// <returns>
-        /// An active coupon redemption on an account.
+        /// Active coupon redemptions on an account.
         /// </returns>
-        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        CouponRedemption GetActiveCouponRedemption(string accountId, RequestOptions options = null);
+        Pager<CouponRedemption> ListActiveCouponRedemptions(string accountId, RequestOptions options = null);
 
-        /// <summary>
-        /// Show the coupon redemption that is active on an account <see href="https://developers.recurly.com/api/v2020-01-01#operation/get_active_coupon_redemption">get_active_coupon_redemption api documentation</see>
-        /// </summary>
-        /// <param name="accountId">Account ID or code. For ID no prefix is used e.g. `e28zov4fw0v2`. For code use prefix `code-`, e.g. `code-bob`.</param>
-        /// <returns>
-        /// An active coupon redemption on an account.
-        /// </returns>
-        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        Task<CouponRedemption> GetActiveCouponRedemptionAsync(string accountId, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null);
 
         /// <summary>
         /// Generate an active coupon redemption on an account <see href="https://developers.recurly.com/api/v2020-01-01#operation/create_coupon_redemption">create_coupon_redemption api documentation</see>
@@ -402,7 +392,7 @@ namespace Recurly
         /// <returns>
         /// A list of the account's credit payments.
         /// </returns>
-        Pager<CreditPayment> ListAccountCreditPayments(string accountId, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, RequestOptions options = null);
+        Pager<CreditPayment> ListAccountCreditPayments(string accountId, ListAccountCreditPaymentsParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -419,7 +409,7 @@ namespace Recurly
         /// <returns>
         /// A list of the account's invoices.
         /// </returns>
-        Pager<Invoice> ListAccountInvoices(string accountId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.FilterInvoiceType? type = null, RequestOptions options = null);
+        Pager<Invoice> ListAccountInvoices(string accountId, ListAccountInvoicesParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -482,7 +472,7 @@ namespace Recurly
         /// <returns>
         /// A list of the account's line items.
         /// </returns>
-        Pager<LineItem> ListAccountLineItems(string accountId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.True? original = null, Constants.LineItemState? state = null, Constants.LintItemType? type = null, RequestOptions options = null);
+        Pager<LineItem> ListAccountLineItems(string accountId, ListAccountLineItemsParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -515,7 +505,7 @@ namespace Recurly
         /// <returns>
         /// A list of an account's notes.
         /// </returns>
-        Pager<AccountNote> ListAccountNotes(string accountId, string ids = null, RequestOptions options = null);
+        Pager<AccountNote> ListAccountNotes(string accountId, ListAccountNotesParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -553,7 +543,7 @@ namespace Recurly
         /// <returns>
         /// A list of an account's shipping addresses.
         /// </returns>
-        Pager<ShippingAddress> ListShippingAddresses(string accountId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, RequestOptions options = null);
+        Pager<ShippingAddress> ListShippingAddresses(string accountId, ListShippingAddressesParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -660,7 +650,7 @@ namespace Recurly
         /// <returns>
         /// A list of the account's subscriptions.
         /// </returns>
-        Pager<Subscription> ListAccountSubscriptions(string accountId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.FilterSubscriptionState? state = null, RequestOptions options = null);
+        Pager<Subscription> ListAccountSubscriptions(string accountId, ListAccountSubscriptionsParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -678,7 +668,7 @@ namespace Recurly
         /// <returns>
         /// A list of the account's transactions.
         /// </returns>
-        Pager<Transaction> ListAccountTransactions(string accountId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.FilterTransactionType? type = null, Constants.True? success = null, RequestOptions options = null);
+        Pager<Transaction> ListAccountTransactions(string accountId, ListAccountTransactionsParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -697,7 +687,7 @@ namespace Recurly
         /// <returns>
         /// A list of an account's child accounts.
         /// </returns>
-        Pager<Account> ListChildAccounts(string accountId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, string email = null, bool? subscriber = null, Constants.True? pastDue = null, RequestOptions options = null);
+        Pager<Account> ListChildAccounts(string accountId, ListChildAccountsParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -712,7 +702,7 @@ namespace Recurly
         /// <returns>
         /// A list of the site's account acquisition data.
         /// </returns>
-        Pager<AccountAcquisition> ListAccountAcquisition(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, RequestOptions options = null);
+        Pager<AccountAcquisition> ListAccountAcquisition(ListAccountAcquisitionParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -727,7 +717,7 @@ namespace Recurly
         /// <returns>
         /// A list of the site's coupons.
         /// </returns>
-        Pager<Coupon> ListCoupons(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, RequestOptions options = null);
+        Pager<Coupon> ListCoupons(ListCouponsParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -825,7 +815,7 @@ namespace Recurly
         /// <returns>
         /// A list of unique coupon codes that were generated
         /// </returns>
-        Pager<UniqueCouponCode> ListUniqueCouponCodes(string couponId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, RequestOptions options = null);
+        Pager<UniqueCouponCode> ListUniqueCouponCodes(string couponId, ListUniqueCouponCodesParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -839,7 +829,7 @@ namespace Recurly
         /// <returns>
         /// A list of the site's credit payments.
         /// </returns>
-        Pager<CreditPayment> ListCreditPayments(int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, RequestOptions options = null);
+        Pager<CreditPayment> ListCreditPayments(ListCreditPaymentsParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -875,7 +865,7 @@ namespace Recurly
         /// <returns>
         /// A list of the site's custom field definitions.
         /// </returns>
-        Pager<CustomFieldDefinition> ListCustomFieldDefinitions(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.RelatedType? relatedType = null, RequestOptions options = null);
+        Pager<CustomFieldDefinition> ListCustomFieldDefinitions(ListCustomFieldDefinitionsParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -911,7 +901,7 @@ namespace Recurly
         /// <returns>
         /// A list of the site's items.
         /// </returns>
-        Pager<Item> ListItems(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.ActiveState? state = null, RequestOptions options = null);
+        Pager<Item> ListItems(ListItemsParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -1029,7 +1019,7 @@ namespace Recurly
         /// <returns>
         /// A list of the site's measured units.
         /// </returns>
-        Pager<MeasuredUnit> ListMeasuredUnit(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.ActiveState? state = null, RequestOptions options = null);
+        Pager<MeasuredUnit> ListMeasuredUnit(ListMeasuredUnitParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -1127,7 +1117,7 @@ namespace Recurly
         /// <returns>
         /// A list of the site's invoices.
         /// </returns>
-        Pager<Invoice> ListInvoices(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.FilterInvoiceType? type = null, RequestOptions options = null);
+        Pager<Invoice> ListInvoices(ListInvoicesParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -1330,7 +1320,7 @@ namespace Recurly
         /// <returns>
         /// A list of the invoice's line items.
         /// </returns>
-        Pager<LineItem> ListInvoiceLineItems(string invoiceId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.True? original = null, Constants.LineItemState? state = null, Constants.LintItemType? type = null, RequestOptions options = null);
+        Pager<LineItem> ListInvoiceLineItems(string invoiceId, ListInvoiceLineItemsParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -1344,7 +1334,7 @@ namespace Recurly
         /// <returns>
         /// A list of the the coupon redemptions associated with the invoice.
         /// </returns>
-        Pager<CouponRedemption> ListInvoiceCouponRedemptions(string invoiceId, string ids = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, RequestOptions options = null);
+        Pager<CouponRedemption> ListInvoiceCouponRedemptions(string invoiceId, ListInvoiceCouponRedemptionsParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -1394,7 +1384,7 @@ namespace Recurly
         /// <returns>
         /// A list of the site's line items.
         /// </returns>
-        Pager<LineItem> ListLineItems(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.True? original = null, Constants.LineItemState? state = null, Constants.LintItemType? type = null, RequestOptions options = null);
+        Pager<LineItem> ListLineItems(ListLineItemsParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -1450,7 +1440,7 @@ namespace Recurly
         /// <returns>
         /// A list of plans.
         /// </returns>
-        Pager<Plan> ListPlans(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.ActiveState? state = null, RequestOptions options = null);
+        Pager<Plan> ListPlans(ListPlansParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -1549,7 +1539,7 @@ namespace Recurly
         /// <returns>
         /// A list of add-ons.
         /// </returns>
-        Pager<AddOn> ListPlanAddOns(string planId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.ActiveState? state = null, RequestOptions options = null);
+        Pager<AddOn> ListPlanAddOns(string planId, ListPlanAddOnsParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -1655,7 +1645,7 @@ namespace Recurly
         /// <returns>
         /// A list of add-ons.
         /// </returns>
-        Pager<AddOn> ListAddOns(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.ActiveState? state = null, RequestOptions options = null);
+        Pager<AddOn> ListAddOns(ListAddOnsParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -1690,7 +1680,7 @@ namespace Recurly
         /// <returns>
         /// A list of the site's shipping methods.
         /// </returns>
-        Pager<ShippingMethod> ListShippingMethods(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, RequestOptions options = null);
+        Pager<ShippingMethod> ListShippingMethods(ListShippingMethodsParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -1788,7 +1778,7 @@ namespace Recurly
         /// <returns>
         /// A list of the site's subscriptions.
         /// </returns>
-        Pager<Subscription> ListSubscriptions(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.FilterSubscriptionState? state = null, RequestOptions options = null);
+        Pager<Subscription> ListSubscriptions(ListSubscriptionsParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -1862,7 +1852,7 @@ namespace Recurly
         /// An expired subscription.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        Subscription TerminateSubscription(string subscriptionId, Constants.RefundType? refund = null, RequestOptions options = null);
+        Subscription TerminateSubscription(string subscriptionId, TerminateSubscriptionParams optionalParams = null, RequestOptions options = null);
 
         /// <summary>
         /// Terminate a subscription <see href="https://developers.recurly.com/api/v2020-01-01#operation/terminate_subscription">terminate_subscription api documentation</see>
@@ -1873,7 +1863,7 @@ namespace Recurly
         /// An expired subscription.
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
-        Task<Subscription> TerminateSubscriptionAsync(string subscriptionId, Constants.RefundType? refund = null, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null);
+        Task<Subscription> TerminateSubscriptionAsync(string subscriptionId, TerminateSubscriptionParams optionalParams = null, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null);
 
         /// <summary>
         /// Cancel a subscription <see href="https://developers.recurly.com/api/v2020-01-01#operation/cancel_subscription">cancel_subscription api documentation</see>
@@ -2075,7 +2065,7 @@ namespace Recurly
         /// <returns>
         /// A list of the subscription's invoices.
         /// </returns>
-        Pager<Invoice> ListSubscriptionInvoices(string subscriptionId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.FilterInvoiceType? type = null, RequestOptions options = null);
+        Pager<Invoice> ListSubscriptionInvoices(string subscriptionId, ListSubscriptionInvoicesParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -2094,7 +2084,7 @@ namespace Recurly
         /// <returns>
         /// A list of the subscription's line items.
         /// </returns>
-        Pager<LineItem> ListSubscriptionLineItems(string subscriptionId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.True? original = null, Constants.LineItemState? state = null, Constants.LintItemType? type = null, RequestOptions options = null);
+        Pager<LineItem> ListSubscriptionLineItems(string subscriptionId, ListSubscriptionLineItemsParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -2108,7 +2098,7 @@ namespace Recurly
         /// <returns>
         /// A list of the the coupon redemptions on a subscription.
         /// </returns>
-        Pager<CouponRedemption> ListSubscriptionCouponRedemptions(string subscriptionId, string ids = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, RequestOptions options = null);
+        Pager<CouponRedemption> ListSubscriptionCouponRedemptions(string subscriptionId, ListSubscriptionCouponRedemptionsParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -2126,7 +2116,7 @@ namespace Recurly
         /// <returns>
         /// A list of the subscription add-on's usage records.
         /// </returns>
-        Pager<Usage> ListUsage(string subscriptionId, string addOnId, string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.UsageSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.BillingStatus? billingStatus = null, RequestOptions options = null);
+        Pager<Usage> ListUsage(string subscriptionId, string addOnId, ListUsageParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -2229,7 +2219,7 @@ namespace Recurly
         /// <returns>
         /// A list of the site's transactions.
         /// </returns>
-        Pager<Transaction> ListTransactions(string ids = null, int? limit = null, Constants.AlphanumericSort? order = null, Constants.TimestampSort? sort = null, DateTime? beginTime = null, DateTime? endTime = null, Constants.FilterTransactionType? type = null, Constants.True? success = null, RequestOptions options = null);
+        Pager<Transaction> ListTransactions(ListTransactionsParams optionalParams = null, RequestOptions options = null);
 
 
         /// <summary>
@@ -2351,5 +2341,43 @@ namespace Recurly
         /// </returns>
         /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
         Task<InvoiceCollection> PreviewPurchaseAsync(PurchaseCreate body, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null);
+
+        /// <summary>
+        /// List the dates that have an available export to download. <see href="https://developers.recurly.com/api/v2020-01-01#operation/get_export_dates">get_export_dates api documentation</see>
+        /// </summary>
+        /// <returns>
+        /// Returns a list of dates.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        ExportDates GetExportDates(RequestOptions options = null);
+
+        /// <summary>
+        /// List the dates that have an available export to download. <see href="https://developers.recurly.com/api/v2020-01-01#operation/get_export_dates">get_export_dates api documentation</see>
+        /// </summary>
+        /// <returns>
+        /// Returns a list of dates.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        Task<ExportDates> GetExportDatesAsync(CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null);
+
+        /// <summary>
+        /// List of the export files that are available to download. <see href="https://developers.recurly.com/api/v2020-01-01#operation/get_export_files">get_export_files api documentation</see>
+        /// </summary>
+        /// <param name="exportDate">Date for which to get a list of available automated export files. Date must be in YYYY-MM-DD format.</param>
+        /// <returns>
+        /// Returns a list of export files to download.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        ExportFiles GetExportFiles(string exportDate, RequestOptions options = null);
+
+        /// <summary>
+        /// List of the export files that are available to download. <see href="https://developers.recurly.com/api/v2020-01-01#operation/get_export_files">get_export_files api documentation</see>
+        /// </summary>
+        /// <param name="exportDate">Date for which to get a list of available automated export files. Date must be in YYYY-MM-DD format.</param>
+        /// <returns>
+        /// Returns a list of export files to download.
+        /// </returns>
+        /// <exception cref="Recurly.Errors.ApiError">Thrown when the request is invalid.</exception>
+        Task<ExportFiles> GetExportFilesAsync(string exportDate, CancellationToken cancellationToken = default(CancellationToken), RequestOptions options = null);
     }
 }

--- a/Recurly/OptionalParams.cs
+++ b/Recurly/OptionalParams.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Recurly
+{
+    public class OptionalParams
+    {
+        public Dictionary<string, object> ToDictionary()
+        {
+            var queryParams = new Dictionary<string, object>();
+            foreach (var x in this.GetType().GetProperties())
+            {
+                var name = x.Name;
+                object[] attrs = x.GetCustomAttributes(true);
+                foreach (object attr in attrs)
+                {
+                    JsonPropertyAttribute jsonAttr = attr as JsonPropertyAttribute;
+                    if (jsonAttr != null)
+                    {
+                        name = jsonAttr.PropertyName;
+                    }
+                }
+                queryParams.Add(name, x.GetValue(this, null));
+            }
+            return queryParams;
+        }
+    }
+}

--- a/Recurly/Resources/AddOn.cs
+++ b/Recurly/Resources/AddOn.cs
@@ -24,6 +24,14 @@ namespace Recurly.Resources
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
         public Constants.AddOnType? AddOnType { get; set; }
 
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the add-on is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_service_type")]
+        public int? AvalaraServiceType { get; set; }
+
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the add-on is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_transaction_type")]
+        public int? AvalaraTransactionType { get; set; }
+
         /// <value>The unique identifier for the add-on within its plan.</value>
         [JsonProperty("code")]
         public string Code { get; set; }
@@ -96,7 +104,9 @@ namespace Recurly.Resources
 
         /// <value>
         /// The pricing model for the add-on.  For more information,
-        /// [click here](https://docs.recurly.com/docs/billing-models#section-quantity-based).
+        /// [click here](https://docs.recurly.com/docs/billing-models#section-quantity-based). See our
+        /// [Guide](https://developers.recurly.com/guides/item-addon-guide.html) for an overview of how
+        /// to configure quantity-based pricing models.
         /// </value>
         [JsonProperty("tier_type")]
         [JsonConverter(typeof(RecurlyStringEnumConverter))]

--- a/Recurly/Resources/AddOnCreate.cs
+++ b/Recurly/Resources/AddOnCreate.cs
@@ -24,6 +24,14 @@ namespace Recurly.Resources
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
         public Constants.AddOnTypeCreate? AddOnType { get; set; }
 
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the add-on is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `AddOn`, then the `avalara_service_type` must be absent.</value>
+        [JsonProperty("avalara_service_type")]
+        public int? AvalaraServiceType { get; set; }
+
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the add-on is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `AddOn`, then the `avalara_transaction_type` must be absent.</value>
+        [JsonProperty("avalara_transaction_type")]
+        public int? AvalaraTransactionType { get; set; }
+
         /// <value>The unique identifier for the add-on within its plan. If `item_code`/`item_id` is part of the request then `code` must be absent. If `item_code`/`item_id` is not present `code` is required.</value>
         [JsonProperty("code")]
         public string Code { get; set; }
@@ -86,7 +94,9 @@ namespace Recurly.Resources
 
         /// <value>
         /// The pricing model for the add-on.  For more information,
-        /// [click here](https://docs.recurly.com/docs/billing-models#section-quantity-based).
+        /// [click here](https://docs.recurly.com/docs/billing-models#section-quantity-based). See our
+        /// [Guide](https://developers.recurly.com/guides/item-addon-guide.html) for an overview of how
+        /// to configure quantity-based pricing models.
         /// </value>
         [JsonProperty("tier_type")]
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
@@ -105,7 +115,11 @@ namespace Recurly.Resources
         [JsonProperty("usage_percentage")]
         public decimal? UsagePercentage { get; set; }
 
-        /// <value>Type of usage, required if `add_on_type` is `usage`.</value>
+        /// <value>
+        /// Type of usage, required if `add_on_type` is `usage`. See our
+        /// [Guide](https://developers.recurly.com/guides/usage-based-billing-guide.html) for an
+        /// overview of how to configure usage add-ons.
+        /// </value>
         [JsonProperty("usage_type")]
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
         public Constants.UsageTypeCreate? UsageType { get; set; }

--- a/Recurly/Resources/AddOnUpdate.cs
+++ b/Recurly/Resources/AddOnUpdate.cs
@@ -19,6 +19,14 @@ namespace Recurly.Resources
         [JsonProperty("accounting_code")]
         public string AccountingCode { get; set; }
 
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the add-on is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `AddOn`, then the `avalara_service_type` must be absent.</value>
+        [JsonProperty("avalara_service_type")]
+        public int? AvalaraServiceType { get; set; }
+
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the add-on is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `AddOn`, then the `avalara_transaction_type` must be absent.</value>
+        [JsonProperty("avalara_transaction_type")]
+        public int? AvalaraTransactionType { get; set; }
+
         /// <value>The unique identifier for the add-on within its plan. If an `Item` is associated to the `AddOn` then `code` must be absent.</value>
         [JsonProperty("code")]
         public string Code { get; set; }

--- a/Recurly/Resources/Coupon.cs
+++ b/Recurly/Resources/Coupon.cs
@@ -15,7 +15,7 @@ namespace Recurly.Resources
     public class Coupon : Resource
     {
 
-        /// <value>The coupon is valid for all plans if true. If false then `plans` and `plans_names` will list the applicable plans.</value>
+        /// <value>The coupon is valid for all plans if true. If false then `plans` will list the applicable plans.</value>
         [JsonProperty("applies_to_all_plans")]
         public bool? AppliesToAllPlans { get; set; }
 
@@ -96,17 +96,9 @@ namespace Recurly.Resources
         [JsonProperty("plans")]
         public List<PlanMini> Plans { get; set; }
 
-        /// <value>TODO</value>
-        [JsonProperty("plans_names")]
-        public List<string> PlansNames { get; set; }
-
         /// <value>The date and time the coupon will expire and can no longer be redeemed. Time is always 11:59:59, the end-of-day Pacific time.</value>
         [JsonProperty("redeem_by")]
         public DateTime? RedeemBy { get; set; }
-
-        /// <value>The date and time the unique coupon code was redeemed. This is only present for bulk coupons.</value>
-        [JsonProperty("redeemed_at")]
-        public DateTime? RedeemedAt { get; set; }
 
         /// <value>Whether the discount is for all eligible charges on the account, or only a specific subscription.</value>
         [JsonProperty("redemption_resource")]
@@ -130,6 +122,10 @@ namespace Recurly.Resources
         /// <value>On a bulk coupon, the template from which unique coupon codes are generated.</value>
         [JsonProperty("unique_code_template")]
         public string UniqueCodeTemplate { get; set; }
+
+        /// <value>Will be populated when the Coupon being returned is a `UniqueCouponCode`.</value>
+        [JsonProperty("unique_coupon_code")]
+        public Dictionary<string, string> UniqueCouponCode { get; set; }
 
         /// <value>When this number reaches `max_redemptions` the coupon will no longer be redeemable.</value>
         [JsonProperty("unique_coupon_codes_count")]

--- a/Recurly/Resources/CouponCreate.cs
+++ b/Recurly/Resources/CouponCreate.cs
@@ -15,7 +15,7 @@ namespace Recurly.Resources
     public class CouponCreate : Request
     {
 
-        /// <value>The coupon is valid for all plans if true. If false then `plans` and `plans_names` will list the applicable plans.</value>
+        /// <value>The coupon is valid for all plans if true. If false then `plans` will list the applicable plans.</value>
         [JsonProperty("applies_to_all_plans")]
         public bool? AppliesToAllPlans { get; set; }
 
@@ -84,7 +84,11 @@ namespace Recurly.Resources
         [JsonProperty("name")]
         public string Name { get; set; }
 
-        /// <value>List of plan codes to which this coupon applies. See `applies_to_all_plans`</value>
+        /// <value>
+        /// List of plan codes to which this coupon applies. Required
+        /// if `applies_to_all_plans` is false. Overrides `applies_to_all_plans`
+        /// when `applies_to_all_plans` is true.
+        /// </value>
         [JsonProperty("plan_codes")]
         public List<string> PlanCodes { get; set; }
 

--- a/Recurly/Resources/ExportDates.cs
+++ b/Recurly/Resources/ExportDates.cs
@@ -1,0 +1,27 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+    [ExcludeFromCodeCoverage]
+    public class ExportDates : Resource
+    {
+
+        /// <value>An array of dates that have available exports.</value>
+        [JsonProperty("dates")]
+        public List<string> Dates { get; set; }
+
+        /// <value>Object type</value>
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+    }
+}

--- a/Recurly/Resources/ExportFile.cs
+++ b/Recurly/Resources/ExportFile.cs
@@ -1,0 +1,31 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+    [ExcludeFromCodeCoverage]
+    public class ExportFile : Resource
+    {
+
+        /// <value>A presigned link to download the export file.</value>
+        [JsonProperty("href")]
+        public string Href { get; set; }
+
+        /// <value>MD5 hash of the export file.</value>
+        [JsonProperty("md5sum")]
+        public string Md5sum { get; set; }
+
+        /// <value>Name of the export file.</value>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+    }
+}

--- a/Recurly/Resources/ExportFiles.cs
+++ b/Recurly/Resources/ExportFiles.cs
@@ -1,0 +1,27 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+    [ExcludeFromCodeCoverage]
+    public class ExportFiles : Resource
+    {
+
+
+        [JsonProperty("files")]
+        public List<ExportFile> Files { get; set; }
+
+        /// <value>Object type</value>
+        [JsonProperty("object")]
+        public string Object { get; set; }
+
+    }
+}

--- a/Recurly/Resources/Item.cs
+++ b/Recurly/Resources/Item.cs
@@ -19,6 +19,14 @@ namespace Recurly.Resources
         [JsonProperty("accounting_code")]
         public string AccountingCode { get; set; }
 
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_service_type")]
+        public int? AvalaraServiceType { get; set; }
+
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_transaction_type")]
+        public int? AvalaraTransactionType { get; set; }
+
         /// <value>Unique code to identify the item.</value>
         [JsonProperty("code")]
         public string Code { get; set; }

--- a/Recurly/Resources/ItemCreate.cs
+++ b/Recurly/Resources/ItemCreate.cs
@@ -19,6 +19,14 @@ namespace Recurly.Resources
         [JsonProperty("accounting_code")]
         public string AccountingCode { get; set; }
 
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_service_type")]
+        public int? AvalaraServiceType { get; set; }
+
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_transaction_type")]
+        public int? AvalaraTransactionType { get; set; }
+
         /// <value>Unique code to identify the item.</value>
         [JsonProperty("code")]
         public string Code { get; set; }

--- a/Recurly/Resources/ItemUpdate.cs
+++ b/Recurly/Resources/ItemUpdate.cs
@@ -19,6 +19,14 @@ namespace Recurly.Resources
         [JsonProperty("accounting_code")]
         public string AccountingCode { get; set; }
 
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_service_type")]
+        public int? AvalaraServiceType { get; set; }
+
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_transaction_type")]
+        public int? AvalaraTransactionType { get; set; }
+
         /// <value>Unique code to identify the item.</value>
         [JsonProperty("code")]
         public string Code { get; set; }

--- a/Recurly/Resources/LineItem.cs
+++ b/Recurly/Resources/LineItem.cs
@@ -35,6 +35,14 @@ namespace Recurly.Resources
         [JsonProperty("amount")]
         public decimal? Amount { get; set; }
 
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the line item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_service_type")]
+        public int? AvalaraServiceType { get; set; }
+
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the line item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_transaction_type")]
+        public int? AvalaraTransactionType { get; set; }
+
         /// <value>When the line item was created.</value>
         [JsonProperty("created_at")]
         public DateTime? CreatedAt { get; set; }

--- a/Recurly/Resources/LineItemCreate.cs
+++ b/Recurly/Resources/LineItemCreate.cs
@@ -19,6 +19,14 @@ namespace Recurly.Resources
         [JsonProperty("accounting_code")]
         public string AccountingCode { get; set; }
 
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the line item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `LineItem`, then the `avalara_service_type` must be absent.</value>
+        [JsonProperty("avalara_service_type")]
+        public int? AvalaraServiceType { get; set; }
+
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the line item is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types. If an `Item` is associated to the `LineItem`, then the `avalara_transaction_type` must be absent.</value>
+        [JsonProperty("avalara_transaction_type")]
+        public int? AvalaraTransactionType { get; set; }
+
         /// <value>The reason the credit was given when line item is `type=credit`. When the Credit Invoices feature is enabled, the value can be set and will default to `general`. When the Credit Invoices feature is not enabled, the value will always be `null`.</value>
         [JsonProperty("credit_reason_code")]
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
@@ -44,10 +52,10 @@ namespace Recurly.Resources
         [JsonProperty("item_id")]
         public string ItemId { get; set; }
 
-        /// <value>Only allowed if the Gift Cards feature is enabled on your site and `type` is `credit`. Can only have a value of `external_gift_card`. Set this value in order to track gift card credits from external gift cards (like InComm). It also skips billing information requirements.</value>
+        /// <value>Origin `external_gift_card` is allowed if the Gift Cards feature is enabled on your site and `type` is `credit`. Set this value in order to track gift card credits from external gift cards (like InComm). It also skips billing information requirements.  Origin `prepayment` is only allowed if `type` is `charge` and `tax_exempt` is left blank or set to true.  This origin creates a charge and opposite credit on the account to be used for future invoices.</value>
         [JsonProperty("origin")]
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
-        public Constants.GiftCodeOrigin? Origin { get; set; }
+        public Constants.LineItemCreateOrigin? Origin { get; set; }
 
         /// <value>Optional field to track a product code or SKU for the line item. This can be used to later reporting on product purchases. For Vertex tax calculations, this field will be used as the Vertex `product` field. If `item_code`/`item_id` is part of the request then `product_code` must be absent.</value>
         [JsonProperty("product_code")]

--- a/Recurly/Resources/ListAccountAcquisitionParams.cs
+++ b/Recurly/Resources/ListAccountAcquisitionParams.cs
@@ -1,0 +1,38 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListAccountAcquisitionParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListAccountCouponRedemptionsParams.cs
+++ b/Recurly/Resources/ListAccountCouponRedemptionsParams.cs
@@ -1,0 +1,32 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListAccountCouponRedemptionsParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListAccountCreditPaymentsParams.cs
+++ b/Recurly/Resources/ListAccountCreditPaymentsParams.cs
@@ -1,0 +1,35 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListAccountCreditPaymentsParams : OptionalParams
+    {
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListAccountInvoicesParams.cs
+++ b/Recurly/Resources/ListAccountInvoicesParams.cs
@@ -1,0 +1,41 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListAccountInvoicesParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+        [JsonProperty("type")]
+        public Constants.FilterInvoiceType? Type { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListAccountLineItemsParams.cs
+++ b/Recurly/Resources/ListAccountLineItemsParams.cs
@@ -1,0 +1,47 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListAccountLineItemsParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+        [JsonProperty("original")]
+        public Constants.True? Original { get; set; }
+
+        [JsonProperty("state")]
+        public Constants.LineItemState? State { get; set; }
+
+        [JsonProperty("type")]
+        public Constants.LintItemType? Type { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListAccountNotesParams.cs
+++ b/Recurly/Resources/ListAccountNotesParams.cs
@@ -1,0 +1,23 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListAccountNotesParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListAccountSubscriptionsParams.cs
+++ b/Recurly/Resources/ListAccountSubscriptionsParams.cs
@@ -1,0 +1,41 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListAccountSubscriptionsParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+        [JsonProperty("state")]
+        public Constants.FilterSubscriptionState? State { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListAccountTransactionsParams.cs
+++ b/Recurly/Resources/ListAccountTransactionsParams.cs
@@ -1,0 +1,44 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListAccountTransactionsParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+        [JsonProperty("type")]
+        public Constants.FilterTransactionType? Type { get; set; }
+
+        [JsonProperty("success")]
+        public Constants.True? Success { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListAccountsParams.cs
+++ b/Recurly/Resources/ListAccountsParams.cs
@@ -1,0 +1,47 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListAccountsParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+        [JsonProperty("email")]
+        public string Email { get; set; }
+
+        [JsonProperty("subscriber")]
+        public bool? Subscriber { get; set; }
+
+        [JsonProperty("past_due")]
+        public Constants.True? PastDue { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListAddOnsParams.cs
+++ b/Recurly/Resources/ListAddOnsParams.cs
@@ -1,0 +1,41 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListAddOnsParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+        [JsonProperty("state")]
+        public Constants.ActiveState? State { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListChildAccountsParams.cs
+++ b/Recurly/Resources/ListChildAccountsParams.cs
@@ -1,0 +1,47 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListChildAccountsParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+        [JsonProperty("email")]
+        public string Email { get; set; }
+
+        [JsonProperty("subscriber")]
+        public bool? Subscriber { get; set; }
+
+        [JsonProperty("past_due")]
+        public Constants.True? PastDue { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListCouponsParams.cs
+++ b/Recurly/Resources/ListCouponsParams.cs
@@ -1,0 +1,38 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListCouponsParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListCreditPaymentsParams.cs
+++ b/Recurly/Resources/ListCreditPaymentsParams.cs
@@ -1,0 +1,35 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListCreditPaymentsParams : OptionalParams
+    {
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListCustomFieldDefinitionsParams.cs
+++ b/Recurly/Resources/ListCustomFieldDefinitionsParams.cs
@@ -1,0 +1,41 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListCustomFieldDefinitionsParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+        [JsonProperty("related_type")]
+        public Constants.RelatedType? RelatedType { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListInvoiceCouponRedemptionsParams.cs
+++ b/Recurly/Resources/ListInvoiceCouponRedemptionsParams.cs
@@ -1,0 +1,32 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListInvoiceCouponRedemptionsParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListInvoiceLineItemsParams.cs
+++ b/Recurly/Resources/ListInvoiceLineItemsParams.cs
@@ -1,0 +1,47 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListInvoiceLineItemsParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+        [JsonProperty("original")]
+        public Constants.True? Original { get; set; }
+
+        [JsonProperty("state")]
+        public Constants.LineItemState? State { get; set; }
+
+        [JsonProperty("type")]
+        public Constants.LintItemType? Type { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListInvoicesParams.cs
+++ b/Recurly/Resources/ListInvoicesParams.cs
@@ -1,0 +1,41 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListInvoicesParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+        [JsonProperty("type")]
+        public Constants.FilterInvoiceType? Type { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListItemsParams.cs
+++ b/Recurly/Resources/ListItemsParams.cs
@@ -1,0 +1,41 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListItemsParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+        [JsonProperty("state")]
+        public Constants.ActiveState? State { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListLineItemsParams.cs
+++ b/Recurly/Resources/ListLineItemsParams.cs
@@ -1,0 +1,47 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListLineItemsParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+        [JsonProperty("original")]
+        public Constants.True? Original { get; set; }
+
+        [JsonProperty("state")]
+        public Constants.LineItemState? State { get; set; }
+
+        [JsonProperty("type")]
+        public Constants.LintItemType? Type { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListMeasuredUnitParams.cs
+++ b/Recurly/Resources/ListMeasuredUnitParams.cs
@@ -1,0 +1,41 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListMeasuredUnitParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+        [JsonProperty("state")]
+        public Constants.ActiveState? State { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListPlanAddOnsParams.cs
+++ b/Recurly/Resources/ListPlanAddOnsParams.cs
@@ -1,0 +1,41 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListPlanAddOnsParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+        [JsonProperty("state")]
+        public Constants.ActiveState? State { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListPlansParams.cs
+++ b/Recurly/Resources/ListPlansParams.cs
@@ -1,0 +1,41 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListPlansParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+        [JsonProperty("state")]
+        public Constants.ActiveState? State { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListShippingAddressesParams.cs
+++ b/Recurly/Resources/ListShippingAddressesParams.cs
@@ -1,0 +1,38 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListShippingAddressesParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListShippingMethodsParams.cs
+++ b/Recurly/Resources/ListShippingMethodsParams.cs
@@ -1,0 +1,38 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListShippingMethodsParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListSitesParams.cs
+++ b/Recurly/Resources/ListSitesParams.cs
@@ -1,0 +1,35 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListSitesParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("state")]
+        public Constants.ActiveState? State { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListSubscriptionCouponRedemptionsParams.cs
+++ b/Recurly/Resources/ListSubscriptionCouponRedemptionsParams.cs
@@ -1,0 +1,32 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListSubscriptionCouponRedemptionsParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListSubscriptionInvoicesParams.cs
+++ b/Recurly/Resources/ListSubscriptionInvoicesParams.cs
@@ -1,0 +1,41 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListSubscriptionInvoicesParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+        [JsonProperty("type")]
+        public Constants.FilterInvoiceType? Type { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListSubscriptionLineItemsParams.cs
+++ b/Recurly/Resources/ListSubscriptionLineItemsParams.cs
@@ -1,0 +1,47 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListSubscriptionLineItemsParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+        [JsonProperty("original")]
+        public Constants.True? Original { get; set; }
+
+        [JsonProperty("state")]
+        public Constants.LineItemState? State { get; set; }
+
+        [JsonProperty("type")]
+        public Constants.LintItemType? Type { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListSubscriptionsParams.cs
+++ b/Recurly/Resources/ListSubscriptionsParams.cs
@@ -1,0 +1,41 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListSubscriptionsParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+        [JsonProperty("state")]
+        public Constants.FilterSubscriptionState? State { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListTransactionsParams.cs
+++ b/Recurly/Resources/ListTransactionsParams.cs
@@ -1,0 +1,44 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListTransactionsParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+        [JsonProperty("type")]
+        public Constants.FilterTransactionType? Type { get; set; }
+
+        [JsonProperty("success")]
+        public Constants.True? Success { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListUniqueCouponCodesParams.cs
+++ b/Recurly/Resources/ListUniqueCouponCodesParams.cs
@@ -1,0 +1,38 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListUniqueCouponCodesParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.TimestampSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/ListUsageParams.cs
+++ b/Recurly/Resources/ListUsageParams.cs
@@ -1,0 +1,41 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class ListUsageParams : OptionalParams
+    {
+
+        [JsonProperty("ids")]
+        public string Ids { get; set; }
+
+        [JsonProperty("limit")]
+        public int? Limit { get; set; }
+
+        [JsonProperty("order")]
+        public Constants.AlphanumericSort? Order { get; set; }
+
+        [JsonProperty("sort")]
+        public Constants.UsageSort? Sort { get; set; }
+
+        [JsonProperty("begin_time")]
+        public DateTime? BeginTime { get; set; }
+
+        [JsonProperty("end_time")]
+        public DateTime? EndTime { get; set; }
+
+        [JsonProperty("billing_status")]
+        public Constants.BillingStatus? BillingStatus { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/Plan.cs
+++ b/Recurly/Resources/Plan.cs
@@ -31,6 +31,14 @@ namespace Recurly.Resources
         [JsonProperty("auto_renew")]
         public bool? AutoRenew { get; set; }
 
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the plan is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_service_type")]
+        public int? AvalaraServiceType { get; set; }
+
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the plan is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_transaction_type")]
+        public int? AvalaraTransactionType { get; set; }
+
         /// <value>Unique code to identify the plan. This is used in Hosted Payment Page URLs and in the invoice exports.</value>
         [JsonProperty("code")]
         public string Code { get; set; }

--- a/Recurly/Resources/PlanCreate.cs
+++ b/Recurly/Resources/PlanCreate.cs
@@ -35,6 +35,14 @@ namespace Recurly.Resources
         [JsonProperty("auto_renew")]
         public bool? AutoRenew { get; set; }
 
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the plan is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_service_type")]
+        public int? AvalaraServiceType { get; set; }
+
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the plan is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_transaction_type")]
+        public int? AvalaraTransactionType { get; set; }
+
         /// <value>Unique code to identify the plan. This is used in Hosted Payment Page URLs and in the invoice exports.</value>
         [JsonProperty("code")]
         public string Code { get; set; }

--- a/Recurly/Resources/PlanUpdate.cs
+++ b/Recurly/Resources/PlanUpdate.cs
@@ -35,6 +35,14 @@ namespace Recurly.Resources
         [JsonProperty("auto_renew")]
         public bool? AutoRenew { get; set; }
 
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the plan is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_service_type")]
+        public int? AvalaraServiceType { get; set; }
+
+        /// <value>Used by Avalara for Communications taxes. The transaction type in combination with the service type describe how the plan is taxed. Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types) for more available t/s types.</value>
+        [JsonProperty("avalara_transaction_type")]
+        public int? AvalaraTransactionType { get; set; }
+
         /// <value>Unique code to identify the plan. This is used in Hosted Payment Page URLs and in the invoice exports.</value>
         [JsonProperty("code")]
         public string Code { get; set; }

--- a/Recurly/Resources/ShippingPurchase.cs
+++ b/Recurly/Resources/ShippingPurchase.cs
@@ -19,7 +19,7 @@ namespace Recurly.Resources
         [JsonProperty("address")]
         public ShippingAddressCreate Address { get; set; }
 
-        /// <value>Assign a shipping address from the account's existing shipping addresses. If this and `shipping_address` are both present, `shipping_address` will take precedence.</value>
+        /// <value>Assign a shipping address from the account's existing shipping addresses. If this and `address` are both present, `address` will take precedence.</value>
         [JsonProperty("address_id")]
         public string AddressId { get; set; }
 

--- a/Recurly/Resources/SubscriptionAddOn.cs
+++ b/Recurly/Resources/SubscriptionAddOn.cs
@@ -60,7 +60,9 @@ namespace Recurly.Resources
 
         /// <value>
         /// The pricing model for the add-on.  For more information,
-        /// [click here](https://docs.recurly.com/docs/billing-models#section-quantity-based).
+        /// [click here](https://docs.recurly.com/docs/billing-models#section-quantity-based). See our
+        /// [Guide](https://developers.recurly.com/guides/item-addon-guide.html) for an overview of how
+        /// to configure quantity-based pricing models.
         /// </value>
         [JsonProperty("tier_type")]
         [JsonConverter(typeof(RecurlyStringEnumConverter))]

--- a/Recurly/Resources/SubscriptionAddOnCreate.cs
+++ b/Recurly/Resources/SubscriptionAddOnCreate.cs
@@ -45,7 +45,8 @@ namespace Recurly.Resources
         /// If the plan add-on's `tier_type` is `flat`, then `tiers` must be absent. The `tiers` object
         /// must include one to many tiers with `ending_quantity` and `unit_amount`.
         /// There must be one tier with an `ending_quantity` of 999999999 which is the
-        /// default if not provided.
+        /// default if not provided. See our [Guide](https://developers.recurly.com/guides/item-addon-guide.html)
+        /// for an overview of how to configure quantity-based pricing models.
         /// </value>
         [JsonProperty("tiers")]
         public List<SubscriptionAddOnTier> Tiers { get; set; }
@@ -57,7 +58,7 @@ namespace Recurly.Resources
         [JsonProperty("unit_amount")]
         public decimal? UnitAmount { get; set; }
 
-        /// <value>The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0. Required if `add_on_type` is usage and `usage_type` is percentage. Must be omitted otherwise. `usage_percentage` does not support tiers.</value>
+        /// <value>The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0. Required if `add_on_type` is usage and `usage_type` is percentage. Must be omitted otherwise. `usage_percentage` does not support tiers. See our [Guide](https://developers.recurly.com/guides/usage-based-billing-guide.html) for an overview of how to configure usage add-ons.</value>
         [JsonProperty("usage_percentage")]
         public decimal? UsagePercentage { get; set; }
 

--- a/Recurly/Resources/SubscriptionChange.cs
+++ b/Recurly/Resources/SubscriptionChange.cs
@@ -31,6 +31,10 @@ namespace Recurly.Resources
         [JsonProperty("created_at")]
         public DateTime? CreatedAt { get; set; }
 
+        /// <value>The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.</value>
+        [JsonProperty("custom_fields")]
+        public List<CustomField> CustomFields { get; set; }
+
         /// <value>Deleted at</value>
         [JsonProperty("deleted_at")]
         public DateTime? DeletedAt { get; set; }
@@ -38,6 +42,10 @@ namespace Recurly.Resources
         /// <value>The ID of the Subscription Change.</value>
         [JsonProperty("id")]
         public string Id { get; set; }
+
+        /// <value>Invoice Collection</value>
+        [JsonProperty("invoice_collection")]
+        public InvoiceCollection InvoiceCollection { get; set; }
 
         /// <value>Object type</value>
         [JsonProperty("object")]

--- a/Recurly/Resources/SubscriptionChangeCreate.cs
+++ b/Recurly/Resources/SubscriptionChangeCreate.cs
@@ -46,6 +46,10 @@ namespace Recurly.Resources
         [JsonProperty("coupon_codes")]
         public List<string> CouponCodes { get; set; }
 
+        /// <value>The custom fields will only be altered when they are included in a request. Sending an empty array will not remove any existing values. To remove a field send the name with a null or empty value.</value>
+        [JsonProperty("custom_fields")]
+        public List<CustomField> CustomFields { get; set; }
+
         /// <value>Integer representing the number of days after an invoice's creation that the invoice will become past due. If an invoice's net terms are set to '0', it is due 'On Receipt' and will become past due 24 hours after it’s created. If an invoice is due net 30, it will become past due at 31 days exactly.</value>
         [JsonProperty("net_terms")]
         public int? NetTerms { get; set; }

--- a/Recurly/Resources/SubscriptionCreate.cs
+++ b/Recurly/Resources/SubscriptionCreate.cs
@@ -32,9 +32,9 @@ namespace Recurly.Resources
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
         public Constants.CollectionMethod? CollectionMethod { get; set; }
 
-        /// <value>Optional coupon code to redeem on the account and discount the subscription. Please note, the subscription request will fail if the coupon is invalid.</value>
-        [JsonProperty("coupon_code")]
-        public string CouponCode { get; set; }
+        /// <value>A list of coupon_codes to be redeemed on the subscription or account during the purchase.</value>
+        [JsonProperty("coupon_codes")]
+        public List<string> CouponCodes { get; set; }
 
         /// <value>If there are pending credits on the account that will be invoiced during the subscription creation, these will be used as the Customer Notes on the credit invoice.</value>
         [JsonProperty("credit_customer_notes")]

--- a/Recurly/Resources/TerminateSubscriptionParams.cs
+++ b/Recurly/Resources/TerminateSubscriptionParams.cs
@@ -1,0 +1,23 @@
+/**
+ * This file is automatically created by Recurly's OpenAPI generation process
+ * and thus any edits you make by hand will be lost. If you wish to make a
+ * change to this file, please create a Github issue explaining the changes you
+ * need and we will usher them to the appropriate places.
+ */
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace Recurly.Resources
+{
+
+    [ExcludeFromCodeCoverage]
+    public class TerminateSubscriptionParams : OptionalParams
+    {
+
+        [JsonProperty("refund")]
+        public Constants.RefundType? Refund { get; set; }
+
+    }
+}
+

--- a/Recurly/Resources/UniqueCouponCode.cs
+++ b/Recurly/Resources/UniqueCouponCode.cs
@@ -15,6 +15,14 @@ namespace Recurly.Resources
     public class UniqueCouponCode : Resource
     {
 
+        /// <value>The Coupon code of the parent Bulk Coupon</value>
+        [JsonProperty("bulk_coupon_code")]
+        public string BulkCouponCode { get; set; }
+
+        /// <value>The Coupon ID of the parent Bulk Coupon</value>
+        [JsonProperty("bulk_coupon_id")]
+        public string BulkCouponId { get; set; }
+
         /// <value>The code the customer enters to redeem the coupon.</value>
         [JsonProperty("code")]
         public string Code { get; set; }

--- a/Recurly/Resources/Usage.cs
+++ b/Recurly/Resources/Usage.cs
@@ -49,7 +49,9 @@ namespace Recurly.Resources
 
         /// <value>
         /// The pricing model for the add-on.  For more information,
-        /// [click here](https://docs.recurly.com/docs/billing-models#section-quantity-based).
+        /// [click here](https://docs.recurly.com/docs/billing-models#section-quantity-based). See our
+        /// [Guide](https://developers.recurly.com/guides/item-addon-guide.html) for an overview of how
+        /// to configure quantity-based pricing models.
         /// </value>
         [JsonProperty("tier_type")]
         [JsonConverter(typeof(RecurlyStringEnumConverter))]
@@ -59,9 +61,17 @@ namespace Recurly.Resources
         [JsonProperty("tiers")]
         public List<SubscriptionAddOnTier> Tiers { get; set; }
 
+        /// <value>Unit price</value>
+        [JsonProperty("unit_amount")]
+        public decimal? UnitAmount { get; set; }
+
         /// <value>When the usage record was billed on an invoice.</value>
         [JsonProperty("updated_at")]
         public DateTime? UpdatedAt { get; set; }
+
+        /// <value>The percentage taken of the monetary amount of usage tracked. This can be up to 4 decimal places. A value between 0.0 and 100.0.</value>
+        [JsonProperty("usage_percentage")]
+        public decimal? UsagePercentage { get; set; }
 
         /// <value>When the usage actually happened. This will define the line item dates this usage is billed under and is important for revenue recognition.</value>
         [JsonProperty("usage_timestamp")]

--- a/openapi/api.yaml
+++ b/openapi/api.yaml
@@ -159,6 +159,7 @@ x-tagGroups:
   - shipping_address
   - purchase
   - usage
+  - automated_exports
 - name: Products and Promotions
   tags:
   - item
@@ -283,6 +284,9 @@ tags:
 - name: shipping_method
   x-displayName: Shipping Method
   description: Shipping methods offered to send products to customers.
+- name: automated_exports
+  x-displayName: Automated Exports
+  description: Automated exports of customer data.
 paths:
   "/sites":
     get:
@@ -329,12 +333,17 @@ paths:
           }
       - lang: Python
         source: |
-          sites = client.list_sites(limit=200).items()
+          params = {"limit": 200}
+          sites = client.list_sites(params=params).items()
           for site in sites:
               print(site.subdomain)
       - lang: ".NET"
         source: |
-          var sites = client.ListSites(limit: 200);
+          var optionalParams = new ListSitesParams()
+          {
+              Limit = 200
+          };
+          var sites = client.ListSites(optionalParams);
           foreach(Site site in sites)
           {
               Console.WriteLine(site.Subdomain);
@@ -545,12 +554,17 @@ paths:
           }
       - lang: Python
         source: |
-          accounts = client.list_accounts(limit=200).items()
+          params = {"limit": 200}
+          accounts = client.list_accounts(params=params).items()
           for account in accounts:
               print(account.code)
       - lang: ".NET"
         source: |
-          var accounts = client.ListAccounts(limit: 200);
+          var optionalParams = new ListAccountsParams()
+          {
+              Limit = 200
+          };
+          var accounts = client.ListAccounts(optionalParams);
           foreach(Account account in accounts)
           {
               Console.WriteLine(account.Code);
@@ -1427,7 +1441,7 @@ paths:
               var acquisitionReq = new AccountAcquisitionUpdatable()
               {
                   Campaign = "big-event-campaign",
-                  Channel = "social_media",
+                  Channel = Channel.SocialMedia,
                   Subchannel = "twitter"
               };
               AccountAcquisition accountAcquisition = client.UpdateAccountAcquisition(accountId, acquisitionReq);
@@ -2304,7 +2318,8 @@ paths:
           }
       - lang: Python
         source: |
-          redemptions = client.list_account_coupon_redemptions(account_id, limit=200).items()
+          params = {"limit": 200}
+          redemptions = client.list_account_coupon_redemptions(account_id, params=params).items()
           for redemption in redemptions:
               print(redemption.id)
       - lang: ".NET"
@@ -2360,18 +2375,20 @@ paths:
       tags:
       - account
       - coupon_redemption
-      operationId: get_active_coupon_redemption
-      summary: Show the coupon redemption that is active on an account
+      operationId: list_active_coupon_redemptions
+      summary: Show the coupon redemptions that are active on an account
+      description: See the [Pagination Guide](/guides/pagination.html) to learn how
+        to use pagination in the API and Client Libraries.
       parameters:
       - "$ref": "#/components/parameters/site_id"
       - "$ref": "#/components/parameters/account_id"
       responses:
         '200':
-          description: An active coupon redemption on an account.
+          description: Active coupon redemptions on an account.
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/CouponRedemption"
+                "$ref": "#/components/schemas/CouponRedemptionList"
         '404':
           description: Incorrect site or account ID.
           content:
@@ -2384,95 +2401,7 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Error"
-      x-code-samples:
-      - lang: Node.js
-        source: |
-          try {
-            const redemption = await client.getActiveCouponRedemption(accountId)
-            console.log('Fetched coupon redemption: ', redemption.id)
-          } catch (err) {
-            if (err instanceof recurly.errors.NotFoundError) {
-              // If the request was not found, you may want to alert the user or
-              // just return null
-              console.log('Resource Not Found')
-            } else {
-              // If we don't know what to do with the err, we should
-              // probably re-raise and let our web framework and logger handle it
-              console.log('Unknown Error: ', err)
-            }
-          }
-      - lang: Python
-        source: |
-          try:
-              redemption = client.get_active_coupon_redemption(account_id)
-              print("Got Redemption %s" % redemption)
-          except recurly.errors.NotFoundError:
-              # If the resource was not found, you may want to alert the user or
-              # just return nil
-              print("Resource Not Found")
-      - lang: ".NET"
-        source: |
-          try
-          {
-              CouponRedemption redemption = client.GetActiveCouponRedemption(accountId);
-              Console.WriteLine($"Fetched coupon redemption {redemption.Id}");
-          }
-          catch (Recurly.Errors.NotFound ex)
-          {
-              // If the resource was not found
-              // we may want to alert the user or just return null
-              Console.WriteLine($"Resource Not Found: {ex.Error.Message}");
-          }
-          catch (Recurly.Errors.ApiError ex)
-          {
-              // Use ApiError to catch a generic error from the API
-              Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
-          }
-      - lang: Ruby
-        source: |
-          begin
-            redemption = @client.get_active_coupon_redemption(account_id: account_id)
-            puts "Got CouponRedemption #{redemption}"
-          rescue Recurly::Errors::NotFoundError
-            # If the resource was not found, you may want to alert the user or
-            # just return nil
-            puts "Resource Not Found"
-          end
-      - lang: Java
-        source: |
-          try {
-              final CouponRedemption redemption = client.getActiveCouponRedemption(accountId);
-              System.out.println("Fetched coupon redemption " + redemption.getId());
-          } catch (NotFoundException e) {
-              // If the resource was not found
-              // we may want to alert the user or just return null
-              System.out.println("Resource Not Found: " + e.getError().getMessage());
-          } catch (ApiException e) {
-              // Use ApiException to catch a generic error from the API
-              System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
-          }
-      - lang: PHP
-        source: |
-          try {
-              $redemption = $client->getActiveCouponRedemption($account_id);
-
-              echo 'Got Redemption:' . PHP_EOL;
-              var_dump($redemption);
-          } catch (\Recurly\Errors\NotFound $e) {
-              // Could not find the resource, you may want to inform the user
-              // or just return a NULL
-              echo 'Could not find resource.' . PHP_EOL;
-              var_dump($e);
-          } catch (\Recurly\RecurlyError $e) {
-              // Something bad happened... tell the user so that they can fix it?
-              echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
-          }
-      - lang: Go
-        source: "couponRedemption, err := client.GetActiveCouponRedemption(accountID)\nif
-          e, ok := err.(*recurly.Error); ok {\n\tif e.Type == recurly.ErrorTypeNotFound
-          {\n\t\tfmt.Printf(\"Resource not found: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
-          Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfmt.Printf(\"Fetched Active
-          Coupon Redemption: %v\", couponRedemption.Id)"
+      x-code-samples: []
     post:
       tags:
       - account
@@ -2772,12 +2701,17 @@ paths:
           }
       - lang: Python
         source: |
-          payments = client.list_account_credit_payments(account_id, limit=200).items()
+          params = {"limit": 200}
+          payments = client.list_account_credit_payments(account_id, params=params).items()
           for payment in payments:
               print(payment.id)
       - lang: ".NET"
         source: |
-          var payments = client.ListAccountCreditPayments(accountId, limit: 200);
+          var optionalParams = new ListAccountCreditPaymentsParams()
+          {
+              Limit = 200
+          };
+          var payments = client.ListAccountCreditPayments(accountId, optionalParams);
           foreach(CreditPayment payment in payments)
           {
               Console.WriteLine(payment.Uuid);
@@ -2877,7 +2811,8 @@ paths:
           }
       - lang: Python
         source: |
-          invoices = client.list_account_invoices(account_id, limit=200).items()
+          params = {"limit": 200}
+          invoices = client.list_account_invoices(account_id, params=params).items()
           for invoice in invoices:
               print(invoice.number)
       - lang: ".NET"
@@ -3016,7 +2951,7 @@ paths:
               var collection = client.CreateInvoice(accountId, new InvoiceCreate()
               {
                   Currency = "USD",
-                  CollectionMethod = "automatic"
+                  CollectionMethod = CollectionMethod.Automatic
               });
               Console.WriteLine("Created Invoice");
               Console.WriteLine(collection.ChargeInvoice);
@@ -3187,7 +3122,7 @@ paths:
               var collection = client.PreviewInvoice(accountId, new InvoiceCreate()
               {
                   Currency = "USD",
-                  CollectionMethod = "automatic"
+                  CollectionMethod = CollectionMethod.Automatic
               });
               Console.WriteLine($"Previewed invoice DueAt {collection.ChargeInvoice.DueAt}");
               Console.WriteLine(collection.ChargeInvoice);
@@ -3325,7 +3260,8 @@ paths:
           }
       - lang: Python
         source: |
-          line_items = client.list_account_line_items(account_id, limit=200).items()
+          params = {"limit": 200}
+          line_items = client.list_account_line_items(account_id, params=params).items()
           for line_item in line_items:
               print(line_item.id)
       - lang: ".NET"
@@ -3462,7 +3398,7 @@ paths:
               {
                   Currency = "USD",
                   UnitAmount = 1000,
-                  Type = "charge" // choose "credit" for a credit
+                  Type = LintItemType.Charge // choose "credit" for a credit
               };
               LineItem lineItem = client.CreateLineItem(accountId, lineItemReq);
               Console.WriteLine($"Created line item {lineItem.Uuid}");
@@ -3587,7 +3523,8 @@ paths:
           }
       - lang: Python
         source: |
-          line_items = client.list_account_line_items(account_id, limit=200).items()
+          params = {"limit": 200}
+          line_items = client.list_account_line_items(account_id, params=params).items()
           for line_item in line_items:
               print(line_item.id)
       - lang: ".NET"
@@ -4507,7 +4444,8 @@ paths:
           }
       - lang: Python
         source: |
-          subscriptions = client.list_account_subscriptions(account.id, limit=200).items()
+          params = {"limit": 200}
+          subscriptions = client.list_account_subscriptions(account.id, params=params).items()
           for subscription in subscriptions:
               print(subscription.uuid)
       - lang: ".NET"
@@ -4612,7 +4550,8 @@ paths:
           }
       - lang: Python
         source: |
-          transactions = client.list_account_transactions(account_id, limit=200).items()
+          params = {"limit": 200}
+          transactions = client.list_account_transactions(account_id, params=params).items()
           for transaction in transactions:
               print("Transaction %s" % transaction.id)
       - lang: ".NET"
@@ -4711,7 +4650,8 @@ paths:
       x-code-samples:
       - lang: Python
         source: |
-          child_accounts = client.list_child_accounts(account_id, limit=200).items()
+          params = {"limit": 200}
+          child_accounts = client.list_child_accounts(account_id, params=params).items()
           for account in child_accounts:
               print("Child Account %s" % account.code)
       - lang: Ruby
@@ -4796,7 +4736,8 @@ paths:
           }
       - lang: Python
         source: |
-          acquisitions = client.list_account_acquisition(limit=200).items()
+          params = {"limit": 200}
+          acquisitions = client.list_account_acquisition(params=params).items()
           for acquisition in acquisitions:
               print(acquisition.id)
       - lang: ".NET"
@@ -4895,12 +4836,17 @@ paths:
           }
       - lang: Python
         source: |
-          coupons = client.list_coupons(limit=200).items()
+          params = {"limit": 200}
+          coupons = client.list_coupons(params=params).items()
           for coupon in coupons:
               print(coupon.code)
       - lang: ".NET"
         source: |
-          var coupons = client.ListCoupons(limit: 200);
+          var optionalParams = new ListCouponsParams()
+          {
+              Limit = 200
+          };
+          var coupons = client.ListCoupons(optionalParams);
           foreach(Coupon coupon in coupons)
           {
               Console.WriteLine(coupon.Code);
@@ -5032,7 +4978,7 @@ paths:
               {
                   Name = "Promotional Coupon",
                   Code = couponCode,
-                  DiscountType = "fixed",
+                  DiscountType = DiscountType.Fixed,
                   Currencies = new List<CouponPricing>() {
                     new CouponPricing() {
                       Currency = "USD",
@@ -5647,12 +5593,17 @@ paths:
           }
       - lang: Python
         source: |
-          payments = client.list_credit_payments(limit=200).items()
+          params = {"limit": 200}
+          payments = client.list_credit_payments(params=params).items()
           for payment in payments:
               print("Credit Payment %s" % payment.id)
       - lang: ".NET"
         source: |
-          var payments = client.ListCreditPayments(limit: 200);
+          var optionalParams = new ListCreditPaymentsParams()
+          {
+              Limit = 200
+          };
+          var payments = client.ListCreditPayments(optionalParams);
           foreach(CreditPayment payment in payments)
           {
               Console.WriteLine(payment.Uuid);
@@ -5779,12 +5730,17 @@ paths:
           }
       - lang: Python
         source: |
-          custom_fields = client.list_custom_field_definitions(limit=200).items()
+          params = {"limit": 200}
+          custom_fields = client.list_custom_field_definitions(params=params).items()
           for custom_field in custom_fields:
               print(custom_field.name)
       - lang: ".NET"
         source: |
-          var fields = client.ListCustomFieldDefinitions(limit: 200);
+          var optionalParams = new ListCustomFieldDefinitionsParams()
+          {
+              Limit = 200
+          };
+          var fields = client.ListCustomFieldDefinitions(optionalParams);
           foreach(CustomFieldDefinition def in fields)
           {
               Console.WriteLine(def.DisplayName);
@@ -5996,12 +5952,17 @@ paths:
           }
       - lang: Python
         source: |
-          items = client.list_items(limit=200).items()
+          params = {"limit": 200}
+          items = client.list_items(params=params).items()
           for item in items:
               print(item.code)
       - lang: ".NET"
         source: |
-          var items = client.ListItems(limit: 200);
+          var optionalParams = new ListItemsParams()
+          {
+              Limit = 200
+          };
+          var items = client.ListItems(optionalParams);
           foreach(Item item in items)
           {
               Console.WriteLine(item.Code);
@@ -6148,7 +6109,7 @@ paths:
                   Description = "Item Description",
                   ExternalSku = "a35JE-44",
                   AccountingCode = "item-code-127",
-                  RevenueScheduleType = "at_range_end",
+                  RevenueScheduleType = RevenueScheduleType.AtRangeEnd,
                   CustomFields = new List<CustomField>() {
                       new CustomField() {
                           Name = "custom-field-1",
@@ -7017,12 +6978,17 @@ paths:
           }
       - lang: Python
         source: |
-          invoices = client.list_invoices(limit=200).items()
+          params = {"limit": 200}
+          invoices = client.list_invoices(params=params).items()
           for invoice in invoices:
               print(invoice.number)
       - lang: ".NET"
         source: |
-          var invoices = client.ListInvoices(limit: 200);
+          var optionalParams = new ListInvoicesParams()
+          {
+              Limit = 200
+          };
+          var invoices = client.ListInvoices(optionalParams);
           foreach(Invoice invoice in invoices)
           {
               Console.WriteLine(invoice.Number);
@@ -7786,7 +7752,8 @@ paths:
       - lang: Python
         source: |
           try:
-              invoice = client.mark_invoice_successful(invoice_id)
+              params = {"limit": 200}
+              invoice = client.mark_invoice_successful(invoice_id, params=params)
               print("Marked Invoice successful %s" % invoice)
           except recurly.errors.ValidationError as e:
               # If the request was invalid, you may want to tell your user
@@ -8209,9 +8176,10 @@ paths:
       - lang: Python
         source: |
           try:
-              line_items = client.list_invoice_line_items(invoice_id, limit=200).items()
+              params = {"limit": 200}
+              line_items = client.list_invoice_line_items(invoice_id, params=params).items()
               for item in line_items:
-                print("Invoice Line Items %s" % item.id)
+                  print("Invoice Line Items %s" % item.id)
           except recurly.errors.NotFoundError:
               # If the resource was not found, you may want to alert the user or
               # just return nil
@@ -8307,14 +8275,10 @@ paths:
           }
       - lang: Python
         source: |
-          try:
-              redemptions = client.list_invoice_coupon_redemptions(invoice_id, limit=200).items()
-              for redemption in redemptions:
-                print("Invoice Coupon Redemption %s" % redemption)
-          except recurly.errors.NotFoundError:
-              # If the resource was not found, you may want to alert the user or
-              # just return nil
-              print("Resource Not Found")
+          params = {"limit": 200}
+          redemptions = client.list_invoice_coupon_redemptions(invoice_id, params=params).items()
+          for redemption in redemptions:
+              print("Invoice Coupon Redemption %s" % redemption)
       - lang: ".NET"
         source: |
           var couponRedemptions = client.ListInvoiceCouponRedemptions(invoiceId);
@@ -8408,9 +8372,10 @@ paths:
       - lang: Python
         source: |
           try:
-              related_invoices = client.list_related_invoices(invoice_id, limit=200).items()
+              params = {"limit": 200}
+              related_invoices = client.list_related_invoices(invoice_id, params=params).items()
               for invoice in related_invoices:
-                print("Related invoice %s" % invoice.id)
+                  print("Related invoice %s" % invoice.id)
           except recurly.errors.NotFoundError:
               # If the resource was not found, you may want to alert the user or
               # just return nil
@@ -8540,7 +8505,7 @@ paths:
           {
               var refundReq = new InvoiceRefund() {
                   CreditCustomerNotes = "Notes on credits",
-                  Type = "amount", // could also be "line_items"
+                  Type = InvoiceRefundType.Amount, // could also be "line_items"
                   Amount = 100
               };
               Invoice invoice = client.RefundInvoice(invoiceId, refundReq);
@@ -8674,12 +8639,17 @@ paths:
           }
       - lang: Python
         source: |
-          line_items = client.list_line_items(limit=200).items()
+          params = {"limit": 200}
+          line_items = client.list_line_items(params=params).items()
           for line_item in line_items:
               print(line_item.id)
       - lang: ".NET"
         source: |
-          var lineItems = client.ListLineItems(limit: 200);
+          var optionalParams = new ListLineItemsParams()
+          {
+              Limit = 200
+          };
+          var lineItems = client.ListLineItems(optionalParams);
           foreach(LineItem item in lineItems)
           {
               Console.WriteLine($"Item {item.Uuid} for {item.Amount}");
@@ -9009,12 +8979,17 @@ paths:
           }
       - lang: Python
         source: |
-          plans = client.list_plans(limit=200).items()
+          params = {"limit": 200}
+          plans = client.list_plans(params=params).items()
           for plan in plans:
               print(plan.code)
       - lang: ".NET"
         source: |
-          var plans = client.ListPlans(limit: 200);
+          var optionalParams = new ListPlansParams()
+          {
+              Limit = 200
+          };
+          var plans = client.ListPlans(optionalParams);
           foreach(Plan plan in plans)
           {
               Console.WriteLine(plan.Code);
@@ -9679,7 +9654,8 @@ paths:
           }
       - lang: Python
         source: |
-          add_ons = client.list_plan_add_ons(plan_id).items()
+          params = {"limit": 200}
+          add_ons = client.list_plan_add_ons(plan_id, params=params).items()
           for add_on in add_ons:
               print(add_on.code)
       - lang: ".NET"
@@ -9822,8 +9798,8 @@ paths:
                   Code = "coffee_grinder",
                   Name = "A quality grinder for your beans",
                   DefaultQuantity = 1,
-                  Currencies = new List<AddOnPricing>() {
-                      new AddOnPricing() {
+                  Currencies = new List<Pricing>() {
+                      new Pricing() {
                           Currency = "USD",
                           UnitAmount = 10000
                       }
@@ -10351,7 +10327,8 @@ paths:
           }
       - lang: Python
         source: |
-          add_ons = client.list_add_ons().items()
+          params = {"limit": 200}
+          add_ons = client.list_add_ons(params=params).items()
           for add_on in add_ons:
               print("Add-On %s" % add_on.code)
       - lang: ".NET"
@@ -10567,9 +10544,10 @@ paths:
           }
       - lang: Python
         source: |
-          shipping_methods = client.list_shipping_methods(limit=200).items()
+          params = {"limit": 200}
+          shipping_methods = client.list_shipping_methods(params=params).items()
           for shipping_method in shipping_methods:
-            print("Shipping Method %s" % shipping_method.code)
+              print("Shipping Method %s" % shipping_method.code)
       - lang: ".NET"
         source: |
           var shippingMethods = client.ListShippingMethods();
@@ -10819,12 +10797,17 @@ paths:
           }
       - lang: Python
         source: |
-          subscriptions = client.list_subscriptions(limit=200).items()
+          params = {"limit": 200}
+          subscriptions = client.list_subscriptions(params=params).items()
           for subscription in subscriptions:
               print(subscription.uuid)
       - lang: ".NET"
         source: |
-          var subscriptions = client.ListSubscriptions(limit: 200);
+          var optionalParams = new ListSubscriptionsParams()
+          {
+              Limit = 200
+          };
+          var subscriptions = client.ListSubscriptions(optionalParams);
           foreach(Subscription subscription in subscriptions)
           {
               Console.WriteLine(subscription.Uuid);
@@ -12271,7 +12254,7 @@ paths:
               var changeReq = new SubscriptionChangeCreate()
               {
                   PlanCode = newPlanCode,
-                  Timeframe = "now" // choose "now" or "renewal"
+                  Timeframe = ChangeTimeframe.Now // choose "now" or "renewal"
               };
               SubscriptionChange change = client.CreateSubscriptionChange(subscriptionId, changeReq);
               Console.WriteLine($"Created subscription change {change.Id}");
@@ -12563,7 +12546,8 @@ paths:
           }
       - lang: Python
         source: |
-          invoices = client.list_subscription_invoices(subscription_id).items()
+          params = {"limit": 200}
+          invoices = client.list_subscription_invoices(subscription_id, params=params).items()
           for invoice in invoices:
               print(invoice.number)
       - lang: ".NET"
@@ -12669,7 +12653,8 @@ paths:
           }
       - lang: Python
         source: |
-          line_items = client.list_subscription_line_items(subscription_id).items()
+          params = {"limit": 200}
+          line_items = client.list_subscription_line_items(subscription_id, params=params).items()
           for line_item in line_items:
               print(line_item.id)
       - lang: ".NET"
@@ -12765,7 +12750,10 @@ paths:
           }
       - lang: Python
         source: |
-          redemptions = client.list_subscription_coupon_redemptions(subscription_id).items()
+          params = {"limit": 200}
+          redemptions = client.list_subscription_coupon_redemptions(
+              subscription_id, params=params
+          ).items()
           for redemption in redemptions:
               print(redemption.uuid)
       - lang: ".NET"
@@ -13085,12 +13073,17 @@ paths:
           }
       - lang: Python
         source: |
-          transactions = client.list_transactions(limit=200).items()
+          params = {"limit": 200}
+          transactions = client.list_transactions(params=params).items()
           for transaction in transactions:
               print(transaction.uuid)
       - lang: ".NET"
         source: |
-          var transactions = client.ListTransactions(limit: 200);
+          var optionalParams = new ListTransactionsParams()
+          {
+              Limit = 200
+          };
+          var transactions = client.ListTransactions(optionalParams);
           foreach(Transaction transaction in transactions)
           {
               Console.WriteLine(transaction.Uuid);
@@ -13811,6 +13804,231 @@ paths:
           {\n\t\tfmt.Printf(\"Failed validation: %v\", e)\n\t\treturn nil, err\n\t}\n\tfmt.Printf(\"Unexpected
           Recurly error: %v\", e)\n\treturn nil, err\n}\nfmt.Printf(\"Preview Charge
           Invoice %v\", collection.ChargeInvoice)"
+  "/sites/{site_id}/export_dates":
+    parameters:
+    - "$ref": "#/components/parameters/site_id"
+    get:
+      tags:
+      - automated_exports
+      operationId: get_export_dates
+      summary: List the dates that have an available export to download.
+      description: Returns a list of dates for which export files are available for
+        download.
+      responses:
+        '200':
+          description: Returns a list of dates.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ExportDates"
+        '400':
+          description: Invalid or unpermitted parameter.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '404':
+          description: Incorrect site ID.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples:
+      - lang: Node.js
+        source: |
+          try {
+            const export_dates = await client.getExportDates()
+            export_dates.dates.forEach(date => {
+              console.log(`Exports are available for: ${date}`)
+            })
+          } catch (err) {
+            if (err instanceof recurly.ApiError) {
+              console.log('Unexpected error', err)
+            }
+          }
+      - lang: Python
+        source: |
+          try:
+              export_dates = client.get_export_dates()
+              for date in export_dates.dates:
+                  print( "Exports are available for: %s" % date)
+          except recurly.errors.NotFoundError:
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              print("Resource Not Found")
+      - lang: ".NET"
+        source: |
+          try
+          {
+              ExportDates exportDates = client.GetExportDates();
+              foreach (var date in exportDates.Dates)
+              {
+                  System.Console.WriteLine($"Exports are available for: {date}");
+              }
+          }
+          catch (Recurly.Errors.ApiError ex)
+          {
+              // Use ApiError to catch a generic error from the API
+              Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+          }
+      - lang: Ruby
+        source: |
+          begin
+            export_dates = @client.get_export_dates()
+            export_dates.dates.each do |date|
+              puts "Exports are available for: #{date}"
+            end
+          rescue Recurly::Errors::NotFoundError
+            # If the resource was not found, you may want to alert the user or
+            # just return nil
+            puts "Resource Not Found"
+          end
+      - lang: Java
+        source: |
+          try {
+              ExportDates exportDates = client.getExportDates();
+              for (String date : exportDates.getDates()) {
+                  System.out.println("Exports are available for: " + date);
+              }
+          } catch (ApiException e) {
+              // Use ApiException to catch a generic error from the API
+              System.out.println("Unexpected Recurly Error: " + e.getError().getMessage());
+          }
+      - lang: PHP
+        source: |
+          try {
+              $export_dates = $client->getExportDates();
+              foreach($export_dates->getDates() as $date)
+              {
+                  echo "Exports are available for: {$date}" . PHP_EOL;
+              }
+          } catch (\Recurly\RecurlyError $e) {
+              echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+          }
+      - lang: Go
+        source: "exportDates, err := client.GetExportDates()\nif e, ok := err.(*recurly.Error);
+          ok {\n\tfmt.Printf(\"Unexpected Recurly error: %v\", e)\n\treturn nil, err\n}\n\nfor
+          _, date := range exportDates.Dates {\n\tfmt.Println(\"Exports are available
+          for: \", date)\n}"
+  "/sites/{site_id}/export_dates/{export_date}/export_files":
+    parameters:
+    - "$ref": "#/components/parameters/site_id"
+    - "$ref": "#/components/parameters/export_date"
+    get:
+      tags:
+      - automated_exports
+      operationId: get_export_files
+      summary: List of the export files that are available to download.
+      description: Returns a list of presigned URLs to download export files for the
+        given date, with their MD5 sums.
+      responses:
+        '200':
+          description: Returns a list of export files to download.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ExportFiles"
+        '400':
+          description: Invalid or unpermitted parameter.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '404':
+          description: Incorrect site ID or date.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+      x-code-samples:
+      - lang: Node.js
+        source: |
+          try {
+            const export_files = await client.getExportFiles(export_date)
+            export_files.files.forEach(file => {
+              console.log(`Export file download URL: ${file.href}`)
+            })
+          } catch (err) {
+            if (err instanceof recurly.ApiError) {
+              console.log('Unexpected error', err)
+            }
+          }
+      - lang: Python
+        source: |
+          try:
+              export_files = client.get_export_files(export_date)
+              for file in export_files.files:
+                  print( "Export file download URL: %s" % file.href)
+          except recurly.errors.NotFoundError:
+              # If the resource was not found, you may want to alert the user or
+              # just return nil
+              print("Resource Not Found")
+      - lang: ".NET"
+        source: |
+          try
+          {
+              ExportFiles exportFiles = client.GetExportFiles(exportDate: exportDate);
+              foreach (var file in exportFiles.Files)
+              {
+                  System.Console.WriteLine($"Export file download URL: {file.Href}");
+              }
+          }
+          catch (Recurly.Errors.ApiError ex)
+          {
+              // Use ApiError to catch a generic error from the API
+              Console.WriteLine($"Unexpected Recurly Error: {ex.Error.Message}");
+          }
+      - lang: Ruby
+        source: |
+          begin
+            export_files = @client.get_export_files(export_date: export_date)
+            export_files.files.each do |file|
+              puts "Export file download URL: #{file.href}"
+            end
+          rescue Recurly::Errors::NotFoundError
+            # If the resource was not found, you may want to alert the user or
+            # just return nil
+            puts "Resource Not Found"
+          end
+      - lang: Java
+        source: |
+          try {
+              ExportFiles exportFiles = client.getExportFiles(exportDate);
+              for (ExportFile file : exportFiles.getFiles()) {
+                  System.out.println("Export file download URL: " + file.getHref());
+              }
+          } catch (ApiException e) {
+              // Use ApiException to catch a generic error from the API
+              System.out.println("Unexpected Recurly Error: " + e.getError());
+          }
+      - lang: PHP
+        source: |
+          try {
+              $export_files = $client->getExportFiles($export_date);
+              foreach($export_files->getFiles() as $file)
+              {
+                  echo "Export file download URL: {$file->getHref()}" . PHP_EOL;
+              }
+          } catch (\Recurly\RecurlyError $e) {
+              echo 'Some unexpected Recurly error happened. Try again later.' . PHP_EOL;
+          }
+      - lang: Go
+        source: "exportFiles, err := client.GetExportFiles(exportDate)\nif e, ok :=
+          err.(*recurly.Error); ok {\n\tfmt.Printf(\"Unexpected Recurly error: %v\",
+          e)\n\treturn nil, err\n}\n\nfor _, file := range exportFiles.Files {\n\tfmt.Println(\"Export
+          file download URL: \", file.Href)\n}"
 servers:
 - url: https://v3.recurly.com
 components:
@@ -14128,6 +14346,14 @@ components:
         - `type=legacy`, only legacy invoices will be returned.
       schema:
         "$ref": "#/components/schemas/FilterInvoiceTypeEnum"
+    export_date:
+      name: export_date
+      in: path
+      description: Date for which to get a list of available automated export files.
+        Date must be in YYYY-MM-DD format.
+      required: true
+      schema:
+        type: string
   securitySchemes:
     api_key:
       type: http
@@ -15001,6 +15227,22 @@ components:
             schedule. If `item_code`/`item_id` is part of the request then `revenue_schedule_type`
             must be absent in the request as the value will be set from the item.
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        avalara_transaction_type:
+          type: integer
+          title: Avalara Transaction Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the add-on is taxed.
+            Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
+        avalara_service_type:
+          type: integer
+          title: Avalara Service Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the add-on is taxed.
+            Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
         tax_code:
           type: string
           title: Tax code
@@ -15168,6 +15410,24 @@ components:
             be included when a subscription is created through the Recurly UI. However,
             the add-on will not be included when a subscription is created through
             the API.
+        avalara_transaction_type:
+          type: integer
+          title: Avalara Transaction Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the add-on is taxed.
+            Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types. If an `Item` is associated to the `AddOn`,
+            then the `avalara_transaction_type` must be absent.
+          minimum: 0
+        avalara_service_type:
+          type: integer
+          title: Avalara Service Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the add-on is taxed.
+            Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types. If an `Item` is associated to the `AddOn`,
+            then the `avalara_service_type` must be absent.
+          minimum: 0
         tax_code:
           type: string
           title: Tax code
@@ -15266,6 +15526,24 @@ components:
             schedule. If `item_code`/`item_id` is part of the request then `revenue_schedule_type`
             must be absent in the request as the value will be set from the item.
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        avalara_transaction_type:
+          type: integer
+          title: Avalara Transaction Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the add-on is taxed.
+            Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types. If an `Item` is associated to the `AddOn`,
+            then the `avalara_transaction_type` must be absent.
+          minimum: 0
+        avalara_service_type:
+          type: integer
+          title: Avalara Service Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the add-on is taxed.
+            Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types. If an `Item` is associated to the `AddOn`,
+            then the `avalara_service_type` must be absent.
+          minimum: 0
         tax_code:
           type: string
           title: Tax code
@@ -15471,7 +15749,7 @@ components:
           maxLength: 22
         iban:
           type: string
-          maxLengh: 34
+          maxLength: 34
           description: The International Bank Account Number, up to 34 alphanumeric
             characters comprising a country code; two check digits; and a number that
             includes the domestic bank account number, branch identifier, and potential
@@ -15522,6 +15800,11 @@ components:
           title: Unique code template
           description: On a bulk coupon, the template from which unique coupon codes
             are generated.
+        unique_coupon_code:
+          allOf:
+          - "$ref": "#/components/schemas/UniqueCouponCode"
+          type: object
+          description: Will be populated when the Coupon being returned is a `UniqueCouponCode`.
         duration:
           title: Duration
           description: |
@@ -15555,19 +15838,13 @@ components:
           type: boolean
           title: Applies to all plans?
           description: The coupon is valid for all plans if true. If false then `plans`
-            and `plans_names` will list the applicable plans.
+            will list the applicable plans.
           default: true
         applies_to_non_plan_charges:
           type: boolean
           title: Applied to all non-plan charges?
           description: The coupon is valid for one-time, non-plan charges if true.
           default: false
-        plans_names:
-          type: array
-          title: 'Plan names (TODO: decide if this duplicates `plans`)'
-          description: TODO
-          items:
-            type: string
         plans:
           type: array
           title: Plans
@@ -15606,13 +15883,6 @@ components:
           description: The date and time the coupon will expire and can no longer
             be redeemed. Time is always 11:59:59, the end-of-day Pacific time.
           format: date-time
-        redeemed_at:
-          type: string
-          title: Redeemed at
-          description: The date and time the unique coupon code was redeemed. This
-            is only present for bulk coupons.
-          format: date-time
-          readOnly: true
         created_at:
           type: string
           title: Created at
@@ -15677,12 +15947,15 @@ components:
             type: boolean
             title: Applies to all plans?
             description: The coupon is valid for all plans if true. If false then
-              `plans` and `plans_names` will list the applicable plans.
+              `plans` will list the applicable plans.
             default: true
           plan_codes:
             type: array
             title: Plan codes
-            description: List of plan codes to which this coupon applies. See `applies_to_all_plans`
+            description: |
+              List of plan codes to which this coupon applies. Required
+              if `applies_to_all_plans` is false. Overrides `applies_to_all_plans`
+              when `applies_to_all_plans` is true.
             items:
               type: string
           duration:
@@ -16192,6 +16465,22 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        avalara_transaction_type:
+          type: integer
+          title: Avalara Transaction Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the item is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
+        avalara_service_type:
+          type: integer
+          title: Avalara Service Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the item is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
         tax_code:
           type: string
           title: Tax code
@@ -16260,6 +16549,22 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        avalara_transaction_type:
+          type: integer
+          title: Avalara Transaction Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the item is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
+        avalara_service_type:
+          type: integer
+          title: Avalara Service Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the item is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
         tax_code:
           type: string
           title: Tax code
@@ -16316,6 +16621,22 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        avalara_transaction_type:
+          type: integer
+          title: Avalara Transaction Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the item is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
+        avalara_service_type:
+          type: integer
+          title: Avalara Service Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the item is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
         tax_code:
           type: string
           title: Tax code
@@ -17013,6 +17334,22 @@ components:
             If not defined, then defaults to the Plan and Site settings. This attribute
             does not work for credits (negative line items). Credits are always applied
             post-tax. Pre-tax discounts should use the Coupons feature."
+        avalara_transaction_type:
+          type: integer
+          title: Avalara Transaction Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the line item is taxed.
+            Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
+        avalara_service_type:
+          type: integer
+          title: Avalara Service Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the line item is taxed.
+            Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
         tax_code:
           type: string
           title: Tax code
@@ -17165,6 +17502,24 @@ components:
             If not defined, then defaults to the Plan and Site settings. This attribute
             does not work for credits (negative line items). Credits are always applied
             post-tax. Pre-tax discounts should use the Coupons feature."
+        avalara_transaction_type:
+          type: integer
+          title: Avalara Transaction Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the line item is taxed.
+            Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types. If an `Item` is associated to the `LineItem`,
+            then the `avalara_transaction_type` must be absent.
+          minimum: 0
+        avalara_service_type:
+          type: integer
+          title: Avalara Service Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the line item is taxed.
+            Refer to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types. If an `Item` is associated to the `LineItem`,
+            then the `avalara_service_type` must be absent.
+          minimum: 0
         tax_code:
           type: string
           title: Tax code
@@ -17185,11 +17540,14 @@ components:
           maxLength: 50
         origin:
           title: Origin
-          description: Only allowed if the Gift Cards feature is enabled on your site
-            and `type` is `credit`. Can only have a value of `external_gift_card`.
-            Set this value in order to track gift card credits from external gift
-            cards (like InComm). It also skips billing information requirements.
-          "$ref": "#/components/schemas/GiftCodeOriginEnum"
+          description: Origin `external_gift_card` is allowed if the Gift Cards feature
+            is enabled on your site and `type` is `credit`. Set this value in order
+            to track gift card credits from external gift cards (like InComm). It
+            also skips billing information requirements.  Origin `prepayment` is only
+            allowed if `type` is `charge` and `tax_exempt` is left blank or set to
+            true.  This origin creates a charge and opposite credit on the account
+            to be used for future invoices.
+          "$ref": "#/components/schemas/LineItemCreateOriginEnum"
         start_date:
           type: string
           format: date-time
@@ -17334,6 +17692,22 @@ components:
             fee. If no value is provided, it defaults to plan's accounting code.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 20
+        avalara_transaction_type:
+          type: integer
+          title: Avalara Transaction Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the plan is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
+        avalara_service_type:
+          type: integer
+          title: Avalara Service Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the plan is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
         tax_code:
           type: string
           title: Tax code
@@ -17466,6 +17840,22 @@ components:
             fee. If no value is provided, it defaults to plan's accounting code.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 20
+        avalara_transaction_type:
+          type: integer
+          title: Avalara Transaction Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the plan is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
+        avalara_service_type:
+          type: integer
+          title: Avalara Service Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the plan is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
         tax_code:
           type: string
           title: Tax code
@@ -17632,6 +18022,22 @@ components:
             fee. If no value is provided, it defaults to plan's accounting code.
           pattern: "/^[a-z0-9_+-]+$/"
           maxLength: 20
+        avalara_transaction_type:
+          type: integer
+          title: Avalara Transaction Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the plan is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
+        avalara_service_type:
+          type: integer
+          title: Avalara Service Type
+          description: Used by Avalara for Communications taxes. The transaction type
+            in combination with the service type describe how the plan is taxed. Refer
+            to [the documentation](https://help.avalara.com/AvaTax_for_Communications/Tax_Calculation/AvaTax_for_Communications_Tax_Engine/Mapping_Resources/TM_00115_AFC_Modules_Corresponding_Transaction_Types)
+            for more available t/s types.
+          minimum: 0
         tax_code:
           type: string
           title: Tax code
@@ -18422,7 +18828,8 @@ components:
             If the plan add-on's `tier_type` is `flat`, then `tiers` must be absent. The `tiers` object
             must include one to many tiers with `ending_quantity` and `unit_amount`.
             There must be one tier with an `ending_quantity` of 999999999 which is the
-            default if not provided.
+            default if not provided. See our [Guide](https://developers.recurly.com/guides/item-addon-guide.html)
+            for an overview of how to configure quantity-based pricing models.
         usage_percentage:
           type: number
           format: float
@@ -18430,7 +18837,8 @@ components:
           description: The percentage taken of the monetary amount of usage tracked.
             This can be up to 4 decimal places. A value between 0.0 and 100.0. Required
             if `add_on_type` is usage and `usage_type` is percentage. Must be omitted
-            otherwise. `usage_percentage` does not support tiers.
+            otherwise. `usage_percentage` does not support tiers. See our [Guide](https://developers.recurly.com/guides/usage-based-billing-guide.html)
+            for an overview of how to configure usage add-ons.
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
@@ -18560,6 +18968,11 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        invoice_collection:
+          title: Invoice Collection
+          "$ref": "#/components/schemas/InvoiceCollection"
+        custom_fields:
+          "$ref": "#/components/schemas/CustomFields"
         created_at:
           type: string
           format: date-time
@@ -18656,6 +19069,8 @@ components:
         revenue_schedule_type:
           title: Revenue schedule type
           "$ref": "#/components/schemas/RevenueScheduleTypeEnum"
+        custom_fields:
+          "$ref": "#/components/schemas/CustomFields"
         po_number:
           type: string
           title: Purchase order number
@@ -18753,12 +19168,13 @@ components:
           title: Add-ons
           items:
             "$ref": "#/components/schemas/SubscriptionAddOnCreate"
-        coupon_code:
-          type: string
-          title: Redeem a coupon and discount the subscription
-          description: Optional coupon code to redeem on the account and discount
-            the subscription. Please note, the subscription request will fail if the
-            coupon is invalid.
+        coupon_codes:
+          type: array
+          title: Coupon codes
+          description: A list of coupon_codes to be redeemed on the subscription or
+            account during the purchase.
+          items:
+            type: string
         custom_fields:
           "$ref": "#/components/schemas/CustomFields"
         trial_ends_at:
@@ -19313,6 +19729,7 @@ components:
             to current datetime.
     UniqueCouponCode:
       type: object
+      description: A unique coupon code for a bulk coupon.
       properties:
         id:
           type: string
@@ -19330,6 +19747,15 @@ components:
           title: State
           description: Indicates if the unique coupon code is redeemable or why not.
           "$ref": "#/components/schemas/CouponCodeStateEnum"
+        bulk_coupon_id:
+          type: string
+          title: Bulk Coupon ID
+          description: The Coupon ID of the parent Bulk Coupon
+          readOnly: true
+        bulk_coupon_code:
+          type: string
+          title: Bulk Coupon code
+          description: The Coupon code of the parent Bulk Coupon
         created_at:
           type: string
           title: Created at
@@ -19413,6 +19839,16 @@ components:
           format: date-time
           description: When the usage actually happened. This will define the line
             item dates this usage is billed under and is important for revenue recognition.
+        usage_percentage:
+          type: number
+          format: float
+          title: Usage Percentage
+          description: The percentage taken of the monetary amount of usage tracked.
+            This can be up to 4 decimal places. A value between 0.0 and 100.0.
+        unit_amount:
+          type: number
+          format: float
+          title: Unit price
         billed_at:
           type: string
           format: date-time
@@ -19559,8 +19995,8 @@ components:
               type: string
               title: Shipping address ID
               description: Assign a shipping address from the account's existing shipping
-                addresses. If this and `shipping_address` are both present, `shipping_address`
-                will take precedence.
+                addresses. If this and `address` are both present, `address` will
+                take precedence.
               maxLength: 13
             address:
               "$ref": "#/components/schemas/ShippingAddressCreate"
@@ -19929,13 +20365,18 @@ components:
       - price
       - percentage
       title: Usage Type
-      description: Type of usage, required if `add_on_type` is `usage`.
+      description: |
+        Type of usage, required if `add_on_type` is `usage`. See our
+        [Guide](https://developers.recurly.com/guides/usage-based-billing-guide.html) for an
+        overview of how to configure usage add-ons.
     TierTypeEnum:
       type: string
       title: Tier type
       description: |
         The pricing model for the add-on.  For more information,
-        [click here](https://docs.recurly.com/docs/billing-models#section-quantity-based).
+        [click here](https://docs.recurly.com/docs/billing-models#section-quantity-based). See our
+        [Guide](https://developers.recurly.com/guides/item-addon-guide.html) for an overview of how
+        to configure quantity-based pricing models.
       default: flat
       enum:
       - flat
@@ -19980,6 +20421,7 @@ components:
       - renewal
       - termination
       - write_off
+      - prepayment
     InvoiceStateEnum:
       type: string
       enum:
@@ -20051,6 +20493,7 @@ components:
       - plan
       - plan_trial
       - setup_fee
+      - prepayment
     FullCreditReasonCodeEnum:
       type: string
       enum:
@@ -20066,10 +20509,11 @@ components:
       - general
       - promotional
       - service
-    GiftCodeOriginEnum:
+    LineItemCreateOriginEnum:
       type: string
       enum:
       - external_gift_card
+      - prepayment
     IntervalUnitEnum:
       type: string
       enum:
@@ -20398,3 +20842,41 @@ components:
       - unknown
       - vaultly_service_unavailable
       - zero_dollar_auth_not_supported
+    ExportDates:
+      type: object
+      properties:
+        object:
+          type: string
+          title: Object type
+          readOnly: true
+        dates:
+          type: array
+          items:
+            type: string
+          title: An array of dates that have available exports.
+    ExportFiles:
+      type: object
+      properties:
+        object:
+          type: string
+          title: Object type
+          readOnly: true
+        files:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ExportFile"
+    ExportFile:
+      type: object
+      properties:
+        name:
+          type: string
+          title: Filename
+          description: Name of the export file.
+        md5sum:
+          type: string
+          title: MD5 hash of the export file
+          description: MD5 hash of the export file.
+        href:
+          type: string
+          title: A link to the export file
+          description: A presigned link to download the export file.


### PR DESCRIPTION
This is an update for the `4.x` version of the client.

Adds the `OptionalParams` class and implementations for each operation that accepts optional parameters. This is to enable the addition of new optional parameters in a manner that will not introduce potential breaking changes as experienced in https://github.com/recurly/recurly-client-dotnet/pull/568. 

3.x Implementation
```csharp
var accounts = client.ListAccounts(limit: 200);
```

4.x Implementation
```csharp
var optionalParams = new ListAccountsParams()
{
    Limit = 200
};
var accounts = client.ListAccounts(optionalParams);
```