### PR TITLE
Release 3.13.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.13.0
+current_version = 3.13.1
 parse = (?P<major>\d+)
 	\.(?P<minor>\d+)
 	\.(?P<patch>\d+)

--- a/Recurly/Recurly.csproj
+++ b/Recurly/Recurly.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
     <PackageId>Recurly</PackageId>
-    <Version>3.13.0</Version>
+    <Version>3.13.1</Version>
     <Authors>dx@recurly.com</Authors>
     <Company>Recurly, Inc.</Company>
     <Title>Recurly API Client</Title>


### PR DESCRIPTION
# Changelog

## [Unreleased](https://github.com/recurly/recurly-client-dotnet/tree/HEAD)

[Full Changelog](https://github.com/recurly/recurly-client-dotnet/compare/3.13.0...HEAD)

**Fixed bugs:**

- Updating client to be compliant with RFC 2616: case-insensitive headers [\#581](https://github.com/recurly/recurly-client-dotnet/pull/581) ([douglasmiller](https://github.com/douglasmiller))