### PR TITLE
Adding support for List types in optional query params

### DIFF
--- a/Recurly.Tests/Fixtures.cs
+++ b/Recurly.Tests/Fixtures.cs
@@ -57,7 +57,7 @@ namespace Recurly.Tests
     public class ListResourcesParams : OptionalParams
     {
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly.Tests/OptionalParamsTest.cs
+++ b/Recurly.Tests/OptionalParamsTest.cs
@@ -11,7 +11,7 @@ namespace Recurly.Tests
         public OptionalParamsTest() { }
 
         [Fact]
-        public void CanDoSomething()
+        public void CanConvertToDictionary()
         {
             var optionalParams = new ListResourcesParams()
             {
@@ -26,6 +26,20 @@ namespace Recurly.Tests
                 Assert.Contains(key, paramsDict.Keys);
             }
             Assert.Equal(200, paramsDict["limit"]);
+        }
+
+        [Fact]
+        public void CanConvertStringLists()
+        {
+            var optionalParams = new ListResourcesParams()
+            {
+                Ids = new List<string>() { "one", "two", "three" }
+            };
+            var paramsDict = optionalParams.ToDictionary();
+
+            Assert.IsType<Dictionary<string, object>>(paramsDict);
+            Assert.Contains("ids", paramsDict.Keys);
+            Assert.Equal("one,two,three", paramsDict["ids"]);
         }
     }
 }

--- a/Recurly/Resources/ListAccountAcquisitionParams.cs
+++ b/Recurly/Resources/ListAccountAcquisitionParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListAccountCouponRedemptionsParams.cs
+++ b/Recurly/Resources/ListAccountCouponRedemptionsParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("sort")]
         public Constants.TimestampSort? Sort { get; set; }

--- a/Recurly/Resources/ListAccountCreditPaymentsParams.cs
+++ b/Recurly/Resources/ListAccountCreditPaymentsParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 

--- a/Recurly/Resources/ListAccountInvoicesParams.cs
+++ b/Recurly/Resources/ListAccountInvoicesParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListAccountLineItemsParams.cs
+++ b/Recurly/Resources/ListAccountLineItemsParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListAccountNotesParams.cs
+++ b/Recurly/Resources/ListAccountNotesParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
     }
 }

--- a/Recurly/Resources/ListAccountSubscriptionsParams.cs
+++ b/Recurly/Resources/ListAccountSubscriptionsParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListAccountTransactionsParams.cs
+++ b/Recurly/Resources/ListAccountTransactionsParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListAccountsParams.cs
+++ b/Recurly/Resources/ListAccountsParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListAddOnsParams.cs
+++ b/Recurly/Resources/ListAddOnsParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListChildAccountsParams.cs
+++ b/Recurly/Resources/ListChildAccountsParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListCouponsParams.cs
+++ b/Recurly/Resources/ListCouponsParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListCreditPaymentsParams.cs
+++ b/Recurly/Resources/ListCreditPaymentsParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 

--- a/Recurly/Resources/ListCustomFieldDefinitionsParams.cs
+++ b/Recurly/Resources/ListCustomFieldDefinitionsParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListInvoiceCouponRedemptionsParams.cs
+++ b/Recurly/Resources/ListInvoiceCouponRedemptionsParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("sort")]
         public Constants.TimestampSort? Sort { get; set; }

--- a/Recurly/Resources/ListInvoiceLineItemsParams.cs
+++ b/Recurly/Resources/ListInvoiceLineItemsParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListInvoicesParams.cs
+++ b/Recurly/Resources/ListInvoicesParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListItemsParams.cs
+++ b/Recurly/Resources/ListItemsParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListLineItemsParams.cs
+++ b/Recurly/Resources/ListLineItemsParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListMeasuredUnitParams.cs
+++ b/Recurly/Resources/ListMeasuredUnitParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListPlanAddOnsParams.cs
+++ b/Recurly/Resources/ListPlanAddOnsParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListPlansParams.cs
+++ b/Recurly/Resources/ListPlansParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListShippingAddressesParams.cs
+++ b/Recurly/Resources/ListShippingAddressesParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListShippingMethodsParams.cs
+++ b/Recurly/Resources/ListShippingMethodsParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListSitesParams.cs
+++ b/Recurly/Resources/ListSitesParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListSubscriptionCouponRedemptionsParams.cs
+++ b/Recurly/Resources/ListSubscriptionCouponRedemptionsParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("sort")]
         public Constants.TimestampSort? Sort { get; set; }

--- a/Recurly/Resources/ListSubscriptionInvoicesParams.cs
+++ b/Recurly/Resources/ListSubscriptionInvoicesParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListSubscriptionLineItemsParams.cs
+++ b/Recurly/Resources/ListSubscriptionLineItemsParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListSubscriptionsParams.cs
+++ b/Recurly/Resources/ListSubscriptionsParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListTransactionsParams.cs
+++ b/Recurly/Resources/ListTransactionsParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListUniqueCouponCodesParams.cs
+++ b/Recurly/Resources/ListUniqueCouponCodesParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/ListUsageParams.cs
+++ b/Recurly/Resources/ListUsageParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 
@@ -16,7 +17,7 @@ namespace Recurly.Resources
     {
 
         [JsonProperty("ids")]
-        public string Ids { get; set; }
+        public IList<string> Ids { get; set; }
 
         [JsonProperty("limit")]
         public int? Limit { get; set; }

--- a/Recurly/Resources/TerminateSubscriptionParams.cs
+++ b/Recurly/Resources/TerminateSubscriptionParams.cs
@@ -5,6 +5,7 @@
  * need and we will usher them to the appropriate places.
  */
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 


### PR DESCRIPTION
This is an update for the `4.x` version of the client and is an extension of https://github.com/recurly/recurly-client-dotnet/pull/582.

This update will allow a developer to specify List/Array optional parameters as a List instead of needing to generate a comma separated string.

3.x Implementation
```csharp
var accounts = client.ListAccounts(ids: "account-id-1,account-id-2,account-id-3");
```

4.x Implementation
```csharp
var optionalParams = new ListAccountsParams()
{
    Ids = new List<string>() {
      "account-id-1",
      "account-id-2",
      "account-id-3",
    }
};
var accounts = client.ListAccounts(optionalParams);
```