### PR TITLE
Add test coverage for unknown error types

### DIFF
--- a/Recurly.Tests/BaseClientTest.cs
+++ b/Recurly.Tests/BaseClientTest.cs
@@ -125,6 +125,15 @@ namespace Recurly.Tests
         }
 
         [Fact]
+        public void WillThrowAnApiErrorForUnknownErrorType()
+        {
+            var client = MockClient.Build(UnknownTypeResponse());
+            // Instead of disabling strict mode, test with ArgumentException as proxy
+            var exception = Assert.Throws<System.ArgumentException>(() => client.GetResource("benjamin", "param1", new DateTime(2020, 01, 01)));
+            Assert.Matches("no valid exception class", exception.Message);
+        }
+
+        [Fact]
         public void WillThrowABadRequestError()
         {
             var client = MockClient.Build(ErrorResponse(System.Net.HttpStatusCode.BadRequest));
@@ -188,6 +197,16 @@ namespace Recurly.Tests
             var response = new Mock<IRestResponse<MyResource>>();
             response.Setup(_ => _.StatusCode).Returns(System.Net.HttpStatusCode.NotFound);
             response.Setup(_ => _.Content).Returns("{\"error\":{ \"type\": \"not_found\", \"message\": \"MyResource not found\"}}");
+            response.Setup(_ => _.Headers).Returns(new List<Parameter> { });
+
+            return response;
+        }
+
+        private Mock<IRestResponse<MyResource>> UnknownTypeResponse()
+        {
+            var response = new Mock<IRestResponse<MyResource>>();
+            response.Setup(_ => _.StatusCode).Returns(System.Net.HttpStatusCode.BadRequest);
+            response.Setup(_ => _.Content).Returns("{\"error\":{ \"type\": \"not_in_spec\", \"message\": \"MyResource not found\"}}");
             response.Setup(_ => _.Headers).Returns(new List<Parameter> { });
 
             return response;

--- a/Recurly/BaseClient.cs
+++ b/Recurly/BaseClient.cs
@@ -195,7 +195,7 @@ namespace Recurly
             // has likely occurred
             if (resp.ErrorException != null)
             {
-                var message = !resp.ErrorException.Equals(null) ? resp.ErrorMessage : $"Unexpected {resp.StatusCode} Error.";
+                var message = resp.ErrorMessage;
                 if (resp.Headers.Any(t => t.Name == "X-Request-ID"))
                 {
                     var requestId = resp.Headers.ToList().Find(x => x.Name == "X-Request-ID").Value.ToString();


### PR DESCRIPTION
Add a test case to verify that unknown error types are thrown as `ApiError`. I'm testing for the desired behavior [by way of `ArgumentException`](https://github.com/recurly/recurly-client-dotnet/blob/master/Recurly/Errors/Factory.cs#L189) which feels wonky. I'm open to any suggestions for a better way to work around [strict mode](https://github.com/recurly/recurly-client-dotnet/blob/master/Recurly/Utils.cs#L11) at test time to allow a more direct test.

See related [#640 in recurly-client-ruby](https://github.com/recurly/recurly-client-ruby/issues/640) and [#369 in recurly-client-python](https://github.com/recurly/recurly-client-python/issues/369) for context.