### PR TITLE
Support item-specific coupons

### DIFF
--- a/Test/CouponTest.cs
+++ b/Test/CouponTest.cs
@@ -160,6 +160,25 @@ namespace Recurly.Test
         }
 
         [RecurlyFact(TestEnvironment.Type.Integration)]
+        public void CreateCouponItem()
+        {
+            var item = new Item(GetMockItemCode("coupon item"), "Coupon Item");
+            item.Create();
+
+            var anotherItem = new Item(GetMockItemCode("another item"), "Another Item");
+            anotherItem.Create();
+
+            var coupon = new Coupon(GetMockCouponCode(), GetMockCouponName(), new Dictionary<string, int>());
+            coupon.DiscountInCents.Add("USD", 200);
+            coupon.Items.Add(item.ItemCode);
+            coupon.Items.Add(anotherItem.ItemCode);
+
+            Action a = coupon.Create;
+            a.ShouldNotThrow();
+            Assert.Equal(2, coupon.Items.Count);
+        }
+
+        [RecurlyFact(TestEnvironment.Type.Integration)]
         public void DeactivateCoupon()
         {
             var discounts = new Dictionary<string, int> { { "USD", 100 }, { "EUR", 50 } };

--- a/Test/CouponTest.cs
+++ b/Test/CouponTest.cs
@@ -170,11 +170,13 @@ namespace Recurly.Test
 
             var coupon = new Coupon(GetMockCouponCode(), GetMockCouponName(), new Dictionary<string, int>());
             coupon.DiscountInCents.Add("USD", 200);
+            coupon.AppliesToAllItems = false;
             coupon.Items.Add(item.ItemCode);
             coupon.Items.Add(anotherItem.ItemCode);
 
             Action a = coupon.Create;
             a.ShouldNotThrow();
+            Assert.False(coupon.AppliesToAllItems);
             Assert.Equal(2, coupon.Items.Count);
         }
 


### PR DESCRIPTION
Add `item_codes` and `applies_to_all_items` to Coupon

Example
```c#
var coupon = new Coupon(
  "special",
  "Special", 
  new Dictionary<string, int>() { { "USD", 200 } }
);
// `applies_to_all_items` defaults to false, so next line is optional
coupon.AppliesToAllItems = false;
coupon.Items.Add("one_item");
coupon.Items.Add("two_item");
coupon.Create();

```