### PR TITLE
Release 1.17.9

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,10 @@
 Unreleased
 ===============
 
+1.17.9 (stable) / 2020-11-05
+===============
+- Support item-specific coupons [PR](https://github.com/recurly/recurly-client-dotnet/pull/588)
+
 1.17.8 (stable) / 2020-09-17
 ===============
 - New endpoint to verify an account's billing information [PR](https://github.com/recurly/recurly-client-dotnet/pull/577)

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.17.8.0")]
-[assembly: AssemblyFileVersion("1.17.8.0")]
+[assembly: AssemblyVersion("1.17.9.0")]
+[assembly: AssemblyFileVersion("1.17.9.0")]

--- a/dist/recurly.nuspec
+++ b/dist/recurly.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>recurly-api-client</id>
-    <version>1.17.8</version>
+    <version>1.17.9</version>
     <authors>recurly</authors>
     <owners>recurly</owners>
     <licenseUrl>https://github.com/recurly/recurly-client-net/blob/master/LICENSE.txt</licenseUrl>


### PR DESCRIPTION
- Bump to dotnet client library version 1.17.9 
- Update history
-----
- Support item-specific coupons https://github.com/recurly/recurly-client-dotnet/pull/588
