### PR TITLE
Expose fields in response xml to developer

### DIFF
--- a/Library/AddOn.cs
+++ b/Library/AddOn.cs
@@ -16,6 +16,7 @@ namespace Recurly
         public string AddOnCode { get; set; }
         public string ItemCode {get; set; }
         public string Name { get; set; }
+        public string ExternalSku { get; private set; }
         public int? DefaultQuantity { get; set; }
         public bool? DisplayQuantityOnHostedPage { get; set; }
         public string TaxCode { get; set; }
@@ -28,7 +29,7 @@ namespace Recurly
         public DateTime CreatedAt { get; private set; }
         public DateTime UpdatedAt { get; private set; }
         public Adjustment.RevenueSchedule? RevenueScheduleType { get; set; }
-        public string ItemState { get; set; }
+        public string ItemState { get; private set; }
         private string _tierType;
         public string TierType { 
           get
@@ -220,6 +221,10 @@ namespace Recurly
 
                     case "item_state":
                         ItemState = reader.ReadElementContentAsString();
+                        break;
+
+                    case "external_sku":
+                        ExternalSku = reader.ReadElementContentAsString();
                         break;
                         
                     case "tier_type":

--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -116,6 +116,11 @@ namespace Recurly
         public string Iban { get; set; }
 
         /// <summary>
+        /// IBAN, last two digits
+        /// </summary>
+        public string LastTwo { get; private set; }
+
+        /// <summary>
         /// Bank identifier code for UK based banks. Required for Bacs based billing infos. (Bacs only)
         /// </summary>
         public string SortCode { get; set; }
@@ -374,6 +379,10 @@ namespace Recurly
 
                     case "last_four":
                         LastFour = reader.ReadElementContentAsString();
+                        break;
+
+                    case "last_two":
+                        LastTwo = reader.ReadElementContentAsString();
                         break;
 
                     case "paypal_billing_agreement_id":


### PR DESCRIPTION
- Because `item_state` and `external_sku` are included in the xml response for item-based add-ons, it would be good practice to expose this fields to the programmer.
- Same applies to `last_two` for `BillingInfo`