### PR TITLE
Repair Lookup Credit Payment endpoint

### DIFF
--- a/Library/CreditPayment.cs
+++ b/Library/CreditPayment.cs
@@ -10,7 +10,7 @@ namespace Recurly
     {
         public string Uuid { get; set; }
         public string Action { get; set; }
-        public int UnitAmountInCents { get; set; }
+        public int AmountInCents { get; set; }
         public string AppliedToInvoice { get; set; }
         public string Currency { get; set; }
         public DateTime CreatedAt { get; set; }
@@ -49,8 +49,8 @@ namespace Recurly
                         Uuid = reader.ReadElementContentAsString();
                         break;
         
-                    case "unit_amount_in_cents":
-                        UnitAmountInCents = reader.ReadElementContentAsInt();
+                    case "amount_in_cents":
+                        AmountInCents = reader.ReadElementContentAsInt();
                         break;
    
                     case "currency":
@@ -109,7 +109,7 @@ namespace Recurly
 
             var creditPayment = new CreditPayment();
             Client.Instance.PerformRequest(Client.HttpRequestMethod.Get,
-                "/credit_payment/" + Uri.EscapeDataString(uuid),
+                "/credit_payments/" + Uri.EscapeDataString(uuid),
                 creditPayment.ReadXml);
             return creditPayment;
         }

--- a/Library/CreditPayment.cs
+++ b/Library/CreditPayment.cs
@@ -10,6 +10,8 @@ namespace Recurly
     {
         public string Uuid { get; set; }
         public string Action { get; set; }
+        [Obsolete("Deprecated, please use AmountInCents")] 
+        public int UnitAmountInCents { get; set; }
         public int AmountInCents { get; set; }
         public string AppliedToInvoice { get; set; }
         public string Currency { get; set; }
@@ -47,6 +49,11 @@ namespace Recurly
                 { 
                     case "uuid":
                         Uuid = reader.ReadElementContentAsString();
+                        break;
+
+                    // Deprecated, please use AmountInCents" 
+                    case "unit_amount_in_cents":
+                        UnitAmountInCents = reader.ReadElementContentAsInt();
                         break;
         
                     case "amount_in_cents":

--- a/Test/CreditPaymentTest.cs
+++ b/Test/CreditPaymentTest.cs
@@ -1,0 +1,21 @@
+using System;
+using FluentAssertions;
+using Xunit;
+using System.Linq;
+
+namespace Recurly.Test
+{
+  public class CreditPaymentTest : BaseTest
+  {
+    [RecurlyFact(TestEnvironment.Type.Integration)]
+    public void LookupCreditPayment()
+    {
+      var collection = CreateNewCollection();
+      var transactionUuid = collection.ChargeInvoice.Transactions[0].Uuid;
+      var cancelledCollection = Purchase.Cancel(transactionUuid);
+      var creditPaymentUuid = CreditPayments.List(FilterCriteria.Instance.WithSort(FilterCriteria.Sort.CreatedAt)).First().Uuid;
+      var creditPayment = CreditPayments.Get(creditPaymentUuid);
+      Assert.Equal(creditPayment.AmountInCents, 629);
+    }
+  }
+}

--- a/Test/PurchaseTest.cs
+++ b/Test/PurchaseTest.cs
@@ -1,6 +1,5 @@
 using System;
 using FluentAssertions;
-// using System.Collections.Generic;
 using Xunit;
 using System.Linq;
 

--- a/Test/Recurly.Test.csproj
+++ b/Test/Recurly.Test.csproj
@@ -94,6 +94,7 @@
     <Compile Include="BillingInfoTest.cs" />
     <Compile Include="CouponRedemptionTest.cs" />
     <Compile Include="CouponTest.cs" />
+    <Compile Include="CreditPaymentTest.cs" />
     <Compile Include="EnumTest.cs" />
     <Compile Include="ExtensionTest.cs" />
     <Compile Include="FixtureImporterTests.cs" />


### PR DESCRIPTION
- Correct request url from /credit_payment/ to /credit_payments/
- Fix AmountInCents attribute, which was previously included as UnitAmountInCent
- Added test for credit payments

Previous calls to [GET /credit_payments/{uuid}](https://developers.recurly.com/api-v2/v2.29/index.html#operation/lookupCreditPayment) would fail due to incorrect request url. Simply adding an 's' resolves the issue