### PR TITLE
Repair PUT /subscriptions/:subscription_id

### DIFF
--- a/Library/Recurly.csproj
+++ b/Library/Recurly.csproj
@@ -139,6 +139,7 @@
     <Compile Include="List\TransactionList.cs" />
     <Compile Include="ValidationException.cs" />
     <Compile Include="Extensions\XmlWriterExtensions.cs" />
+    <Compile Include="SubscriptionAddOnTier.cs" />
     <Compile Include="Tier.cs" />
     <Compile Include="VerifyBillingInfo.cs" />
   </ItemGroup>

--- a/Library/SubscriptionAddOn.cs
+++ b/Library/SubscriptionAddOn.cs
@@ -15,14 +15,14 @@ namespace Recurly
         public float? UsagePercentage { get; set; }
         public string TierType { get; set; }
 
-        private List<Tier> _tiers; 
+        private List<SubscriptionAddOnTier> _tiers; 
 
         /// <summary>
         /// List of tiers for this add-on
         /// </summary>
-        public List<Tier> Tiers
+        public List<SubscriptionAddOnTier> Tiers
         {
-            get {return _tiers ?? (_tiers = new List<Tier>()); }
+            get {return _tiers ?? (_tiers = new List<SubscriptionAddOnTier>()); }
             set { _tiers = value; }
         }
 
@@ -114,14 +114,14 @@ namespace Recurly
                         break;
 
                     case "tiers":
-                        Tiers = new List<Tier>();
+                        Tiers = new List<SubscriptionAddOnTier>();
                         while (reader.Read())
                         {
                             if (reader.Name == "tiers" && reader.NodeType == XmlNodeType.EndElement)
                                 break;
                             else if (reader.NodeType == XmlNodeType.Element && reader.Name == "tier")
                             {
-                                Tiers.Add(new Tier(reader));
+                                Tiers.Add(new SubscriptionAddOnTier(reader));
                             }
                         }
                         break;

--- a/Library/SubscriptionAddOnTier.cs
+++ b/Library/SubscriptionAddOnTier.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Xml;
+
+namespace Recurly 
+{
+  /// <summary>
+  /// Represents subscription add-on tiers
+  /// </summary>
+  public class SubscriptionAddOnTier : RecurlyEntity
+  {
+    public int? EndingQuantity { get; set; }
+
+    public int? UnitAmountInCents { get; set; }
+
+    #region Constructors
+
+    public SubscriptionAddOnTier() {
+    }
+
+    internal SubscriptionAddOnTier(XmlTextReader xmlReader){
+      ReadXml(xmlReader);
+    }
+
+    #endregion
+
+    #region Read and Write XML documents
+
+    internal override void ReadXml(XmlTextReader reader)
+    {
+
+      while (reader.Read())
+      {
+        if (reader.Name == "tier" && reader.NodeType == XmlNodeType.EndElement)
+          break;
+
+        if (reader.NodeType != XmlNodeType.Element) continue;
+        switch (reader.Name){
+          case "unit_amount_in_cents":
+            UnitAmountInCents = reader.ReadElementContentAsInt();
+            break;
+
+          case "ending_quantity":
+            EndingQuantity = reader.ReadElementContentAsInt();
+            break;
+        }
+      }
+    }
+
+    internal override void WriteXml(XmlTextWriter xmlWriter){
+      WriteXml(xmlWriter, false);
+    }
+
+    internal void WriteEmbeddedXml(XmlTextWriter xmlWriter){
+      WriteXml(xmlWriter, true);
+    }
+
+    internal void WriteXml(XmlTextWriter xmlWriter, bool embedded = false){
+      xmlWriter.WriteStartElement("tier");
+
+      if (UnitAmountInCents.HasValue)   
+        xmlWriter.WriteElementString("unit_amount_in_cents", UnitAmountInCents.Value.AsString());
+  
+      if (EndingQuantity.HasValue)
+        xmlWriter.WriteElementString("ending_quantity", EndingQuantity.Value.AsString());
+
+      xmlWriter.WriteEndElement();
+    }
+
+    #endregion
+  }
+}

--- a/Test/Recurly.Test.csproj
+++ b/Test/Recurly.Test.csproj
@@ -116,6 +116,7 @@
     <Compile Include="PurchaseTest.cs" />
     <Compile Include="SettingsManagerTest.cs" />
     <Compile Include="SubscriptionTest.cs" />
+    <Compile Include="SubscriptionAddOnTest.cs" />
     <Compile Include="SystemTest.cs" />
     <Compile Include="TestCreditCardNumbers.cs" />
     <Compile Include="TestEnvironment.cs" />

--- a/Test/SubscriptionAddOnTest.cs
+++ b/Test/SubscriptionAddOnTest.cs
@@ -1,0 +1,147 @@
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace Recurly.Test
+{
+  public class SubscriptionAddOnTest : BaseTest
+  {
+    [RecurlyFact(TestEnvironment.Type.Integration)]
+    public void CreateSubscriptionAddOn()
+    {
+      var account = CreateNewAccountWithBillingInfo();   
+      var plan = new Plan(GetMockPlanCode(), GetMockPlanName()) {Description = "Test Lookup"};
+      plan.UnitAmountInCents.Add("USD", 100);
+      plan.Create();
+      PlansToDeactivateOnDispose.Add(plan);
+
+      var addon = plan.NewAddOn("extra-padding", "Extra Padding");
+      addon.UnitAmountInCents.Add("USD", 200);
+      addon.DefaultQuantity = 1;
+      addon.DisplayQuantityOnHostedPage = true;
+      addon.Create();
+
+      var subscription = new Subscription(account, plan, "USD");
+      subscription.AddOns.Add(addon.AddOnCode, 3);
+      subscription.Create();
+
+      subscription.AddOns[0].Quantity.Should().Be(3);
+      subscription.AddOns[0].AddOnCode.Should().Be("extra-padding");
+    }
+
+    [RecurlyFact(TestEnvironment.Type.Integration)]
+    public void CreateSubscriptionAddOnWithTiers()
+    {
+      var account = CreateNewAccountWithBillingInfo();   
+      var plan = new Plan(GetMockPlanCode(), GetMockPlanName()) {Description = "Test Lookup"};
+      plan.UnitAmountInCents.Add("USD", 100);
+      plan.Create();
+      PlansToDeactivateOnDispose.Add(plan);
+
+      var addon = plan.NewAddOn("tiered-add-on", "Tiered Add-On");
+      addon.TierType = "tiered";
+      addon.DisplayQuantityOnHostedPage = true;
+
+      var tier1 = new Tier();
+      tier1.UnitAmountInCents.Add("USD", 123);
+      tier1.EndingQuantity = 50;
+      addon.Tiers.Add(tier1);
+
+      var tier2 = new Tier();
+      tier2.UnitAmountInCents.Add("USD", 99);
+      addon.Tiers.Add(tier2);
+
+      addon.Create();
+
+      var subscription = new Subscription(account, plan, "USD");
+      subscription.AddOns.Add(plan.GetAddOn(addon.AddOnCode), addon.TierType, 2);
+      subscription.Create();
+
+      subscription.AddOns[0].Tiers[0].UnitAmountInCents.Should().Be(123);
+      subscription.AddOns[0].Tiers[1].EndingQuantity.Should().Be(999999999);
+    }
+
+    [RecurlyFact(TestEnvironment.Type.Integration)]
+    public void UpdateSubscriptionAddOn()
+    {
+      var account = CreateNewAccountWithBillingInfo();   
+      var plan = new Plan(GetMockPlanCode(), GetMockPlanName()) {Description = "Test Lookup"};
+      plan.UnitAmountInCents.Add("USD", 100);
+      plan.Create();
+      PlansToDeactivateOnDispose.Add(plan);
+
+      var addon = plan.NewAddOn("extra-padding", "Extra Padding");
+      addon.UnitAmountInCents.Add("USD", 200);
+      addon.DefaultQuantity = 1;
+      addon.DisplayQuantityOnHostedPage = true;
+      addon.Create();
+
+      var subscription = new Subscription(account, plan, "USD");
+      subscription.AddOns.Add(addon.AddOnCode, 3);
+      subscription.Create();
+
+      subscription.Quantity.Should().Be(1);
+      subscription.AddOns[0].Quantity.Should().Be(3);
+
+      var change = new SubscriptionChange {
+        TimeFrame = SubscriptionChange.ChangeTimeframe.Now,
+        Quantity = 2,
+        AddOns = new SubscriptionAddOnList()
+      };
+
+      var quantity = 3;
+      var amountInCents = 199;
+      change.AddOns.Add(addon.AddOnCode, quantity, amountInCents);
+
+      subscription = Subscription.ChangeSubscription(subscription.Uuid, change);
+
+      subscription.Quantity.Should().Be(2);
+      subscription.AddOns[0].Quantity.Should().Be(3);
+    }
+
+    [RecurlyFact(TestEnvironment.Type.Integration)]
+    public void UpdateSubscriptionAddOnWithTiers()
+    {
+      var account = CreateNewAccountWithBillingInfo();   
+      var plan = new Plan(GetMockPlanCode(), GetMockPlanName()) {Description = "Test Lookup"};
+      plan.UnitAmountInCents.Add("USD", 100);
+      plan.Create();
+      PlansToDeactivateOnDispose.Add(plan);
+
+      var addon = plan.NewAddOn("tiered-add-on", "Tiered Add-On");
+      addon.TierType = "tiered";
+      addon.DisplayQuantityOnHostedPage = true;
+
+      var tier1 = new Tier();
+      tier1.UnitAmountInCents.Add("USD", 100);
+      tier1.EndingQuantity = 50;
+      addon.Tiers.Add(tier1);
+
+      var tier2 = new Tier();
+      tier2.UnitAmountInCents.Add("USD", 89);
+      addon.Tiers.Add(tier2);
+
+      addon.Create();
+
+      var subscription = new Subscription(account, plan, "USD");
+      subscription.AddOns.Add(plan.GetAddOn(addon.AddOnCode), addon.TierType, 2);
+      subscription.Create();
+
+      var change = new SubscriptionChange {
+        TimeFrame = SubscriptionChange.ChangeTimeframe.Now,
+        AddOns = new SubscriptionAddOnList()
+      };
+      SubscriptionAddOn subaddon = subscription.AddOns[0];
+      var subTier1 = subaddon.Tiers[0];
+      subTier1.UnitAmountInCents = 99;
+      var subTier2 = subaddon.Tiers[1];
+      subTier2.UnitAmountInCents = 79;
+      change.AddOns.Add(subaddon);
+
+      Subscription.ChangeSubscription(subscription.Uuid, change);
+
+      subscription.AddOns[0].Tiers[0].UnitAmountInCents.Should().Be(99);
+      subscription.AddOns[0].Tiers[1].UnitAmountInCents.Should().Be(79);
+    }
+  }
+}


### PR DESCRIPTION
- Create SubscriptionAddOnTier class to allow updating, where UnitAmountInCents is an integer, not a dictionary of strings and integers
- Update SubscriptionAddOn class to use SubscriptionAddOnTier, not Tier
- Create tests for SubscriptionAddOn

Though it would be more simple to have one Tier class, subscription-based add-on tiers are different from plan add-on tiers in that `unit_amount_in_cents` must be an integer for the former and a dictionary of currencies and values for the latter. Therefore SubscriptionAddOnTier is a required class if we want to be able to update quantity-based subscription add-ons.

Addresses https://github.com/recurly/recurly-client-dotnet/pull/561

Example:
```c#
var subscription = Subscriptions.Get("44f83d7cba354d5b84812419f923ea96");

var change = new SubscriptionChange {
        TimeFrame = SubscriptionChange.ChangeTimeframe.Now,
        AddOns = new SubscriptionAddOnList()
};
SubscriptionAddOn subaddon = subscription.AddOns[0];
var subTier1 = subaddon.Tiers[0];
subTier1.UnitAmountInCents = 99;
var subTier2 = subaddon.Tiers[1];
subTier2.UnitAmountInCents = 79;
change.AddOns.Add(subaddon);

Subscription.ChangeSubscription(subscription.Uuid, change);
```

Sample request xml:
```xml
<?xml version="1.0" encoding="utf-8"?>
<subscription>
  <timeframe>now</timeframe>
  <subscription_add_ons>
    <subscription_add_on>
      <add_on_code>ipaddresses</add_on_code>
      <quantity>1</quantity>
      <tier_type>tiered</tier_type>
      <tiers>
        <tier>
          <unit_amount_in_cents>99</unit_amount_in_cents>
          <ending_quantity>100</ending_quantity>
        </tier>
        <tier>
          <unit_amount_in_cents>79</unit_amount_in_cents>
          <ending_quantity>999999999</ending_quantity>
        </tier>
      </tiers>
      <add_on_source>plan_add_on</add_on_source>
    </subscription_add_on>
  </subscription_add_ons>
</subscription>
```