### PR TITLE
Add missing UnionPay enum to BillingInfo

### DIFF
--- a/Library/BillingInfo.cs
+++ b/Library/BillingInfo.cs
@@ -21,7 +21,8 @@ namespace Recurly
             Forbrugsforeningen,
             Laser,
             Unknown,
-            DinersClub
+            DinersClub,
+            UnionPay
         }
 
         public enum HppType : short

--- a/Library/Extensions/StringExtensions.cs
+++ b/Library/Extensions/StringExtensions.cs
@@ -181,6 +181,11 @@ namespace Recurly
                 type = BillingInfo.CreditCardType.MasterCard;
                 return card.Length == 16 && card.PassesLuhnsTest();
             }
+            if (firstTwo == 62 && card.Length >= 16 && card.Length <= 19)
+            {
+                type = BillingInfo.CreditCardType.UnionPay;
+                return card.PassesLuhnsTest();
+            }
 
             var firstFour = Int32.Parse(card.Substring(0, 4));
             var firstThree = Int32.Parse(card.Substring(0, 3));

--- a/Test/BillingInfoTest.cs
+++ b/Test/BillingInfoTest.cs
@@ -246,6 +246,7 @@ namespace Recurly.Test
          InlineData(TestCreditCardNumbers.MasterCard2, true, CreditCardType.MasterCard),
          InlineData(TestCreditCardNumbers.JCB1, true, CreditCardType.JCB),
          InlineData(TestCreditCardNumbers.JCB2, true, CreditCardType.JCB),
+         InlineData(TestCreditCardNumbers.UnionPay1, true, CreditCardType.UnionPay),
          InlineData("not a card number", false, CreditCardType.Invalid),
          InlineData("1801 1234 1234 1234", false, CreditCardType.Invalid),
          InlineData("too short", false, CreditCardType.Invalid),

--- a/Test/TestCreditCardNumbers.cs
+++ b/Test/TestCreditCardNumbers.cs
@@ -20,5 +20,7 @@ namespace Recurly.Test
         public const string Visa1 = "4111111111111111";
         public const string Visa2 = "4012888888881881";
         public const string Visa3 = "4222222222222";
+
+        public const string UnionPay1 = "6221261111113245";
     }
 }


### PR DESCRIPTION
- Add UnionPay as CreditCardType enum in BillingInfo class
- Include tests