### PR TITLE
Expose HTTP timeout for Recurly.BaseClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ var client = new Recurly.Client(apiKey);
 var sub = client.GetSubscription("uuid-abcd123456")
 ```
 
+Optional arguments can be provided through object initializers.
+
+```csharp
+var client = new Recurly.Client(apiKey) { Timeout = 5000 }
+```
+
 ### Operations
 
 The `Recurly.Client` contains every `operation` you can perform on the site as a list of methods. Each method is documented explaining

--- a/Recurly.Tests/BaseClientTest.cs
+++ b/Recurly.Tests/BaseClientTest.cs
@@ -17,6 +17,17 @@ namespace Recurly.Tests
             Assert.Throws<ArgumentException>(() => new MockClient(""));
         }
 
+        /*
+         * Assert that Timeout can be set and retrieved. Take on faith for now
+         * that RestSharp timeouts are well-behaved.
+         */
+        [Fact]
+        public void CanInitializeWithATimeout()
+        {
+            var client = new Recurly.Client("myapikey") { Timeout = 124 };
+            Assert.Equal(124, client.Timeout);
+        }
+
         [Fact]
         public void RespondsWithGivenApiVersion()
         {

--- a/Recurly/BaseClient.cs
+++ b/Recurly/BaseClient.cs
@@ -50,6 +50,13 @@ namespace Recurly
             RestClient.AddDefaultHeader("Content-Type", "application/json");
         }
 
+        /// <value>Timeout in milliseconds to be used for the request</value>
+        public int Timeout
+        {
+            get { return RestClient.Timeout; }
+            set { RestClient.Timeout = value; }
+        }
+
         public async Task<T> MakeRequestAsync<T>(Method method, string url, Request body = null, Dictionary<string, object> queryParams = null, RequestOptions options = null, CancellationToken cancellationToken = default(CancellationToken)) where T : Resource
         {
             Debug.WriteLine($"Calling {url}");


### PR DESCRIPTION
Given that the unit tests mock the HTTP client at the RestSharp interface level, I was unable to automate validation of the timeout functionality. A simple test has been added to verify that the property can be initialized and read back.

I did however modify some playground scripts and manually confirm that it was behaving as expected.

![image](https://user-images.githubusercontent.com/73194015/105734025-ca5da580-5ef7-11eb-8ca4-ba7408cf1129.png)

In the past, I've verified configured timeouts by making a real HTTP connection to a debug server launched by the test runner. Unclear how to approach that in this repo as:

1. overriding the endpoint URL at test time is tricky
2. unclear if a barebones Kestrel server can be raised at test time

Open to suggestions for improvement.