### PR TITLE
usageId type needs to match nullable type

### DIFF
--- a/Library/Usage.cs
+++ b/Library/Usage.cs
@@ -272,7 +272,7 @@ namespace Recurly
             return new UsageList(UrlPrefix(subscriptionUuid, subscriptionAddOnCode) + "?" + parameters.ToString());
         }
 
-        public static Usage Get(string subscriptionUuid, string subscriptionAddOnCode, long usageId)
+        public static Usage Get(string subscriptionUuid, string subscriptionAddOnCode, long? usageId)
         {
             if (string.IsNullOrWhiteSpace(subscriptionUuid) || string.IsNullOrWhiteSpace(subscriptionAddOnCode))
             {


### PR DESCRIPTION
 `usageId` type needs to match nullable type established in Id getter/setter in order for `Get` to function properly (for example, when passing in a variable as a param instead of the actual id itself).

This is valid:
```c#
Usages.Get("374ae5e848adcfd332fdd3469d89c888", "video_streaming", 450646065398417338);
```

This fails with error `error CS1503: Argument 3: cannot convert from 'long?' to 'long'`
```c#
Usages.Get("374ae5e848adcfd332fdd3469d89c888", "video_streaming", usage.Id)
```

Will need to add testing for Usage, since it doesn't currently exist, but that will be in the future