### PR TITLE
Bump to dotnet client library version 1.17.10 and update history

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,13 @@
 Unreleased
 ===============
 
+1.17.10 (stable) / 2021-02-22
+- Fix test: create billing info (IBAN) [PR](https://github.com/recurly/recurly-client-dotnet/pull/592)
+- Expose fields in response xml to developer [PR](https://github.com/recurly/recurly-client-dotnet/pull/593)
+- Repair Lookup Credit Payment endpoint [PR](https://github.com/recurly/recurly-client-dotnet/pull/602)
+- Repair PUT /subscriptions/:subscription_id [PR](https://github.com/recurly/recurly-client-dotnet/pull/604)
+- Add missing UnionPay enum to BillingInfo [PR](https://github.com/recurly/recurly-client-dotnet/pull/605)
+
 1.17.9 (stable) / 2020-11-05
 ===============
 - Support item-specific coupons [PR](https://github.com/recurly/recurly-client-dotnet/pull/588)

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.17.9.0")]
-[assembly: AssemblyFileVersion("1.17.9.0")]
+[assembly: AssemblyVersion("1.17.10.0")]
+[assembly: AssemblyFileVersion("1.17.10.0")]

--- a/dist/recurly.nuspec
+++ b/dist/recurly.nuspec
@@ -2,14 +2,14 @@
 <package >
   <metadata>
     <id>recurly-api-client</id>
-    <version>1.17.9</version>
+    <version>1.17.10</version>
     <authors>recurly</authors>
     <owners>recurly</owners>
     <licenseUrl>https://github.com/recurly/recurly-client-net/blob/master/LICENSE.txt</licenseUrl>
     <projectUrl>https://github.com/recurly/recurly-client-net</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>An API Client for Recurly - Subscription billing automation.</description>
-    <copyright>Copyright 2020</copyright>
+    <copyright>Copyright 2021</copyright>
     <tags>billing api client subscription recurly</tags>
   </metadata>
 </package>


### PR DESCRIPTION
- Bump to dotnet client library version 1.17.10
- Update history
-----
- Fix test: create billing info (IBAN) https://github.com/recurly/recurly-client-dotnet/pull/592
- Expose fields in response xml to developer https://github.com/recurly/recurly-client-dotnet/pull/593
- Repair Lookup Credit Payment endpoint https://github.com/recurly/recurly-client-dotnet/pull/602
- Repair PUT /subscriptions/:subscription_id https://github.com/recurly/recurly-client-dotnet/pull/604
- Add missing UnionPay enum to BillingInfo https://github.com/recurly/recurly-client-dotnet/pull/605
