### PR TITLE
Convert query string enums to their EnumMember Value

### DIFF
--- a/Recurly.Tests/UtilsTest.cs
+++ b/Recurly.Tests/UtilsTest.cs
@@ -28,8 +28,9 @@ namespace Recurly.Tests
             d.Add("int", 123);
             d.Add("decimal", 123.456m);
             d.Add("date", new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+            d.Add("enum", Recurly.Tests.Constants.EnumValue.AllowedEnum);
             var result = Utils.QueryString(d);
-            Assert.Equal("?trueBool=true&falseBool=false&int=123&decimal=123.456&date=2020-01-01T00:00:00.000Z", result);
+            Assert.Equal("?trueBool=true&falseBool=false&int=123&decimal=123.456&date=2020-01-01T00:00:00.000Z&enum=allowed_enum", result);
         }
     }
 }

--- a/Recurly/Utils.cs
+++ b/Recurly/Utils.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Runtime.Serialization;
 using System.Text;
 
 namespace Recurly
@@ -58,6 +59,26 @@ namespace Recurly
                     if (param.Value.GetType() == typeof(DateTime))
                     {
                         stringRepr = ISO8601((DateTime)param.Value);
+                    }
+                    else if (param.Value is Enum)
+                    {
+                        // Use the string value by default
+                        stringRepr = param.Value.ToString();
+
+                        var type = param.Value.GetType();
+                        Console.WriteLine($"TYPE {type}");
+                        var memInfos = type.GetMember(param.Value.ToString());
+                        foreach (var memInfo in memInfos)
+                            foreach (var attr in memInfo.GetCustomAttributes(true))
+                            {
+                                EnumMemberAttribute enumAttr = attr as EnumMemberAttribute;
+                                if (enumAttr != null)
+                                {
+                                    // Use the EnumMember Value if it exists
+                                    stringRepr = enumAttr.Value;
+                                }
+                            }
+
                     }
                     else if (param.Value is bool)
                     {


### PR DESCRIPTION
An extension of #471 which added Enum support. Query string parameters were not properly using the EnumMember Value annotation when generating the request.