### PR TITLE
Updating release script to be more defensive

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -7,8 +7,17 @@ set -e
 # ./release
 #
 
+# Environment verification
+if [ -z "$NUGET_TOKEN" ]; then
+  echo "NUGET_TOKEN must be set. Aborting."
+  exit 1
+fi
+
+#clean
+rm -rf "$(pwd)"/Recurly/bin/
+
 #publish
 dotnet pack -c Release
 dotnet build -c Release
-dotnet nuget push "$(pwd)"/Recurly/bin/Release/Recurly."$THIS_VERSION".nupkg -s https://api.nuget.org/v3/index.json -k "$NUGET_TOKEN"
+dotnet nuget push "$(pwd)"/Recurly/bin/Release/Recurly.*.nupkg -s https://api.nuget.org/v3/index.json -k "$NUGET_TOKEN"
 


### PR DESCRIPTION
Removing dependence on an environment variable to determine the current version and adding a guard statement for the `NUGET_TOKEN`.